### PR TITLE
Better error messages for `DryRunInspector.from_single_response()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## `v0.1.2`
+
+### Fixed
+
+* Misleading error message in the case of an erroring dry run response
+
 ## `v0.1.1`
 
 ### Added

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -449,6 +449,9 @@ class DryRunInspector:
 
     @classmethod
     def from_single_response(cls, dryrun_resp: dict) -> "DryRunInspector":
+        error = dryrun_resp.get("error")
+        assert not error, f"dryrun response included the following error: [{error}]"
+
         txns = dryrun_resp.get("txns") or []
         assert (
             len(txns) == 1

--- a/tests/unit/inspector_test.py
+++ b/tests/unit/inspector_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from graviton.blackbox import DryRunInspector
+
+
+def test_from_single_response_errors():
+    error_resp = {
+        "error": "dryrun Source[0]: 1 error",
+        "protocol-version": "future",
+        "txns": None,
+    }
+
+    with pytest.raises(AssertionError) as ae:
+        DryRunInspector.from_single_response(error_resp)
+
+    assert (
+        ae.value.args[0]
+        == "dryrun response included the following error: [dryrun Source[0]: 1 error]"
+    )
+
+    no_txns_resp1 = {
+        "error": None,
+        "protocol-version": "future",
+        "txns": None,
+    }
+
+    with pytest.raises(AssertionError) as ae:
+        DryRunInspector.from_single_response(no_txns_resp1)
+
+    assert (
+        ae.value.args[0]
+        == "require exactly 1 dry run transaction to create a singleton but had 0 instead"
+    )
+
+    no_txns_resp2 = {
+        "protocol-version": "future",
+        "txns": None,
+    }
+
+    with pytest.raises(AssertionError) as ae:
+        DryRunInspector.from_single_response(no_txns_resp2)
+
+    assert (
+        ae.value.args[0]
+        == "require exactly 1 dry run transaction to create a singleton but had 0 instead"
+    )
+
+    too_many_txns_resp = {"protocol-version": "future", "txns": [1, 2, 3]}
+
+    with pytest.raises(AssertionError) as ae:
+        DryRunInspector.from_single_response(too_many_txns_resp)
+
+    assert (
+        ae.value.args[0]
+        == "require exactly 1 dry run transaction to create a singleton but had 3 instead"
+    )
+
+    too_many_txns_resp_w_err = {
+        "error": "this is REALLLY REALLY BAD!!!",
+        "protocol-version": "future",
+        "txns": [1, 2, 3],
+    }
+
+    with pytest.raises(AssertionError) as ae:
+        DryRunInspector.from_single_response(too_many_txns_resp_w_err)
+
+    assert (
+        ae.value.args[0]
+        == "dryrun response included the following error: [this is REALLLY REALLY BAD!!!]"
+    )

--- a/tests/unit/sanity_test.py
+++ b/tests/unit/sanity_test.py
@@ -1,2 +1,0 @@
-def test_noop():
-    assert True, "oh no"


### PR DESCRIPTION
# First Real Unit Test

@algoidurovic pointed out the following confusing error that he encountered while using graviton for a test (cv. [this pyteal commit](https://github.com/algorand/pyteal/pull/307/commits/0716822f762a1c12a050ee31f8c05440615af3c8)):

> require exactly 1 dry run transaction to create a singleton but had 0 instead

This PR will first check the existence of "error" in the dry-run response, and pass that through when encountered.

Additionally: Discarding the former `sanity_test.py` which was just a stub in favor or `inspector_test.py`