### PR TITLE
ABI Functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## `v0.2.0` (_aka_ 🐗)
+
+### Added
+
+* ABI Functionality
+
 ## `v0.1.2`
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ blackbox-smoke-prefix:
 integration-test:
 	pytest -sv tests/integration
 
+all-tests: lint unit-test integration-test
 
 ###### Local Only ######
 

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -511,10 +511,9 @@ class DryRunInspector:
             raise ValueError(f"unknown config options: {bad_keys}")
 
         for k, v in kwargs.items():
-            if v is not None:
-                assert isinstance(
-                    v, bool
-                ), f"configuration {k}=[{v}] must be bool but was {type(v)}"
+            assert isinstance(
+                v, bool
+            ), f"configuration {k}=[{v}] must be bool but was {type(v)}"
 
             setattr(self, k, v)
 

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -252,7 +252,7 @@ class DryRunEncoder:
             a_len, t_len = len(args), len(abi_types)
             assert (
                 a_len == t_len
-            ), f"mismatch between args (length={a_len}) anbd abi_types (length={t_len})"
+            ), f"mismatch between args (length={a_len}) and abi_types (length={t_len})"
         return [
             cls._encode_arg(a, i, abi_types[i] if abi_types else None)
             for i, a in enumerate(args)

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -497,7 +497,7 @@ class DryRunInspector:
             suppress_abi=False, force_abi=False, has_abi_prefix=bool(self.abi_type)
         )
 
-    def config(self, **kwargs: dict[str, bool]):
+    def config(self, **kwargs: Dict[str, bool]):
         bad_keys = set(kwargs.keys()) - self.CONFIG_OPTIONS
         if bad_keys:
             raise ValueError(f"unknown config options: {bad_keys}")

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -270,6 +270,8 @@ class DryRunEncoder:
 
     @classmethod
     def _encode_arg(cls, arg, idx):
+        if isinstance(arg, bytes):
+            return arg
         cls._assert_encodable(arg, f"problem encoding arg ({arg}) at index ({idx})")
         return cls._to_bytes(arg, only_ints=True)
 

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -481,7 +481,7 @@ class DryRunInspector:
         - returns True if there was no error, or the actual error when an error occured
     """
 
-    CONFIG_OPTIONS = {"suppress_abi", "force_abi", "has_abi_prefix"}
+    CONFIG_OPTIONS = {"suppress_abi", "has_abi_prefix"}
 
     def __init__(self, dryrun_resp: dict, txn_index: int, abi_type: abi.ABIType = None):
         txns = dryrun_resp.get("txns", [])
@@ -501,9 +501,7 @@ class DryRunInspector:
         self.abi_type = abi_type
 
         # config options:
-        self.config(
-            suppress_abi=False, force_abi=False, has_abi_prefix=bool(self.abi_type)
-        )
+        self.config(suppress_abi=False, has_abi_prefix=bool(self.abi_type))
 
     def config(self, **kwargs: Dict[str, bool]):
         bad_keys = set(kwargs.keys()) - self.CONFIG_OPTIONS

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -586,7 +586,9 @@ class DryRunInspector:
         """
         return self.dig(DRProp.cost) if self.is_app() else None
 
-    def last_log(self, suppress_abi: bool = False) -> Optional[str]:
+    def last_log(
+        self, suppress_abi: bool = False, has_abi_prefix: bool = False
+    ) -> Optional[str]:
         """Assertable property for the last log that was printed during dry run execution
         return type: string representing the hex bytes of the final log
         available Mode: Application only
@@ -598,10 +600,13 @@ class DryRunInspector:
         if not self.abi_type or suppress_abi:
             return res
 
-        # TODO: this may be more subtle
-        return self.abi_type.decode(res)
+        if has_abi_prefix:
+            res = res[8:]  # skip the first 8 hex char's = first 4 bytes
+        return self.abi_type.decode(bytes.fromhex(res))
 
-    def stack_top(self, suppress_abi: bool = False) -> Union[int, str]:
+    def stack_top(
+        self, suppress_abi: bool = False, skip_abi_return_prefix: bool = False
+    ) -> Union[int, str]:
         """Assertable property for the contents of the top of the stack and the end of a dry run execution
         return type: int or string
         available: all modes
@@ -610,7 +615,8 @@ class DryRunInspector:
         if not self.abi_type or suppress_abi:
             return res
 
-        # TODO: this may be more subtle
+        if skip_abi_return_prefix:
+            res = res[4:]
         return self.abi_type.decode(res)
 
     def logs(self) -> Optional[List[str]]:

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -318,10 +318,16 @@ class DryRunExecutor:
         algod: AlgodClient,
         teal: str,
         args: Sequence[Union[str, int]],
+        abi_types: List[Optional[abi.ABIType]] = None,
         sender: str = ZERO_ADDRESS,
     ) -> "DryRunInspector":
         return cls.execute_one_dryrun(
-            algod, teal, args, ExecutionMode.Application, sender=sender
+            algod,
+            teal,
+            args,
+            ExecutionMode.Application,
+            abi_types=abi_types,
+            sender=sender,
         )
 
     @classmethod
@@ -330,10 +336,16 @@ class DryRunExecutor:
         algod: AlgodClient,
         teal: str,
         args: Sequence[Union[str, int]],
+        abi_types: List[Optional[abi.ABIType]] = None,
         sender: str = ZERO_ADDRESS,
     ) -> "DryRunInspector":
         return cls.execute_one_dryrun(
-            algod, teal, args, ExecutionMode.Signature, sender
+            algod,
+            teal,
+            args,
+            ExecutionMode.Signature,
+            abi_types=abi_types,
+            sender=sender,
         )
 
     @classmethod
@@ -342,9 +354,10 @@ class DryRunExecutor:
         algod: AlgodClient,
         teal: str,
         inputs: List[Sequence[Union[str, int]]],
+        abi_types: List[Optional[abi.ABIType]] = None,
         sender: str = ZERO_ADDRESS,
     ) -> List["DryRunInspector"]:
-        return cls._map(cls.dryrun_app, algod, teal, inputs, sender)
+        return cls._map(cls.dryrun_app, algod, teal, inputs, abi_types, sender)
 
     @classmethod
     def dryrun_logicsig_on_sequence(
@@ -352,13 +365,14 @@ class DryRunExecutor:
         algod: AlgodClient,
         teal: str,
         inputs: List[Sequence[Union[str, int]]],
+        abi_types: List[Optional[abi.ABIType]] = None,
         sender: str = ZERO_ADDRESS,
     ) -> List["DryRunInspector"]:
-        return cls._map(cls.dryrun_logicsig, algod, teal, inputs, sender)
+        return cls._map(cls.dryrun_logicsig, algod, teal, inputs, abi_types, sender)
 
     @classmethod
-    def _map(cls, f, algod, teal, inps, sndr):
-        return list(map(lambda args: f(algod, teal, args, sender=sndr), inps))
+    def _map(cls, f, algod, teal, inps, abi_types, sndr):
+        return list(map(lambda args: f(algod, teal, args, abi_types, sndr), inps))
 
     @classmethod
     def execute_one_dryrun(
@@ -367,6 +381,7 @@ class DryRunExecutor:
         teal: str,
         args: Sequence[Union[str, int]],
         mode: ExecutionMode,
+        abi_types: List[Optional[abi.ABIType]] = None,
         sender: str = ZERO_ADDRESS,
     ) -> "DryRunInspector":
         assert (
@@ -375,7 +390,7 @@ class DryRunExecutor:
         assert mode in ExecutionMode, f"unknown mode {mode} of type {type(mode)}"
         is_app = mode == ExecutionMode.Application
 
-        args = DryRunEncoder.encode_args(args)
+        args = DryRunEncoder.encode_args(args, abi_types=abi_types)
         builder = (
             DryRunHelper.singleton_app_request
             if is_app

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -564,7 +564,7 @@ class DryRunInspector:
         """
         return self.dig(DRProp.cost) if self.is_app() else None
 
-    def last_log(self) -> Optional[str]:
+    def last_log(self, suppress_abi: bool = False) -> Optional[str]:
         """Assertable property for the last log that was printed during dry run execution
         return type: string representing the hex bytes of the final log
         available Mode: Application only
@@ -593,7 +593,7 @@ class DryRunInspector:
         """
         return self.dig(DRProp.maxStackHeight)
 
-    def stack_top(self) -> Union[int, str]:
+    def stack_top(self, suppress_abi: bool = False) -> Union[int, str]:
         """Assertable property for the contents of the top of the stack and the end of a dry run execution
         return type: int or string
         available: all modes

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -240,7 +240,7 @@ class DryRunEncoder:
     def encode_args(
         cls,
         args: Sequence[Union[bytes, str, int]],
-        abi_types: List[Optional[abi.ABIType]],
+        abi_types: List[Optional[abi.ABIType]] = None,
     ) -> List[str]:
         """
         Encoding convention for Black Box Testing.
@@ -248,6 +248,11 @@ class DryRunEncoder:
         * Assumes int's are uint64 and encodes them as such
         * Leaves str's alone
         """
+        if abi_types:
+            a_len, t_len = len(args), len(abi_types)
+            assert (
+                a_len == t_len
+            ), f"mismatch between args (length={a_len}) anbd abi_types (length={t_len})"
         return [
             cls._encode_arg(a, i, abi_types[i] if abi_types else None)
             for i, a in enumerate(args)

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -318,8 +318,8 @@ class DryRunExecutor:
         algod: AlgodClient,
         teal: str,
         args: Sequence[Union[str, int]],
-        abi_arg_types: List[Optional[abi.ABIType]] = None,
-        abi_ret_type: abi.ABIType = None,
+        abi_argument_types: List[Optional[abi.ABIType]] = None,
+        abi_return_type: abi.ABIType = None,
         sender: str = ZERO_ADDRESS,
     ) -> "DryRunInspector":
         return cls.execute_one_dryrun(
@@ -327,8 +327,8 @@ class DryRunExecutor:
             teal,
             args,
             ExecutionMode.Application,
-            abi_arg_types=abi_arg_types,
-            abi_ret_type=abi_ret_type,
+            abi_argument_types=abi_argument_types,
+            abi_return_type=abi_return_type,
             sender=sender,
         )
 
@@ -338,8 +338,8 @@ class DryRunExecutor:
         algod: AlgodClient,
         teal: str,
         args: Sequence[Union[str, int]],
-        abi_arg_types: List[Optional[abi.ABIType]] = None,
-        abi_ret_type: abi.ABIType = None,
+        abi_argument_types: List[Optional[abi.ABIType]] = None,
+        abi_return_type: abi.ABIType = None,
         sender: str = ZERO_ADDRESS,
     ) -> "DryRunInspector":
         return cls.execute_one_dryrun(
@@ -347,8 +347,8 @@ class DryRunExecutor:
             teal,
             args,
             ExecutionMode.Signature,
-            abi_arg_types=abi_arg_types,
-            abi_ret_type=abi_ret_type,
+            abi_argument_types=abi_argument_types,
+            abi_return_type=abi_return_type,
             sender=sender,
         )
 
@@ -358,12 +358,18 @@ class DryRunExecutor:
         algod: AlgodClient,
         teal: str,
         inputs: List[Sequence[Union[str, int]]],
-        abi_arg_types: List[Optional[abi.ABIType]] = None,
-        abi_ret_type: abi.ABIType = None,
+        abi_argument_types: List[Optional[abi.ABIType]] = None,
+        abi_return_type: abi.ABIType = None,
         sender: str = ZERO_ADDRESS,
     ) -> List["DryRunInspector"]:
         return cls._map(
-            cls.dryrun_app, algod, teal, inputs, abi_arg_types, abi_ret_type, sender
+            cls.dryrun_app,
+            algod,
+            teal,
+            inputs,
+            abi_argument_types,
+            abi_return_type,
+            sender,
         )
 
     @classmethod
@@ -372,8 +378,8 @@ class DryRunExecutor:
         algod: AlgodClient,
         teal: str,
         inputs: List[Sequence[Union[str, int]]],
-        abi_arg_types: List[Optional[abi.ABIType]] = None,
-        abi_ret_type: abi.ABIType = None,
+        abi_argument_types: List[Optional[abi.ABIType]] = None,
+        abi_return_type: abi.ABIType = None,
         sender: str = ZERO_ADDRESS,
     ) -> List["DryRunInspector"]:
         return cls._map(
@@ -381,8 +387,8 @@ class DryRunExecutor:
             algod,
             teal,
             inputs,
-            abi_arg_types,
-            abi_ret_type,
+            abi_argument_types,
+            abi_return_type,
             sender,
         )
 
@@ -399,8 +405,8 @@ class DryRunExecutor:
         teal: str,
         args: Sequence[Union[str, int]],
         mode: ExecutionMode,
-        abi_arg_types: List[Optional[abi.ABIType]] = None,
-        abi_ret_type: abi.ABIType = None,
+        abi_argument_types: List[Optional[abi.ABIType]] = None,
+        abi_return_type: abi.ABIType = None,
         sender: str = ZERO_ADDRESS,
     ) -> "DryRunInspector":
         assert (
@@ -409,7 +415,7 @@ class DryRunExecutor:
         assert mode in ExecutionMode, f"unknown mode {mode} of type {type(mode)}"
         is_app = mode == ExecutionMode.Application
 
-        args = DryRunEncoder.encode_args(args, abi_types=abi_arg_types)
+        args = DryRunEncoder.encode_args(args, abi_types=abi_argument_types)
         builder = (
             DryRunHelper.singleton_app_request
             if is_app
@@ -417,7 +423,9 @@ class DryRunExecutor:
         )
         dryrun_req = builder(teal, args, sender=sender)
         dryrun_resp = algod.dryrun(dryrun_req)
-        return DryRunInspector.from_single_response(dryrun_resp, abi_type=abi_ret_type)
+        return DryRunInspector.from_single_response(
+            dryrun_resp, abi_type=abi_return_type
+        )
 
 
 class DryRunInspector:

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -236,7 +236,7 @@ class DryRunEncoder:
     """Encoding utilities for dry run executions and results"""
 
     @classmethod
-    def encode_args(cls, args: Sequence[Union[str, int]]) -> List[str]:
+    def encode_args(cls, args: Sequence[Union[bytes, str, int]]) -> List[str]:
         """
         Encoding convention for Black Box Testing.
 
@@ -270,15 +270,13 @@ class DryRunEncoder:
 
     @classmethod
     def _encode_arg(cls, arg, idx):
-        if isinstance(arg, bytes):
-            return arg
         cls._assert_encodable(arg, f"problem encoding arg ({arg}) at index ({idx})")
         return cls._to_bytes(arg, only_ints=True)
 
     @classmethod
     def _assert_encodable(cls, arg: Any, msg: str = "") -> None:
         assert isinstance(
-            arg, (int, str)
+            arg, (bytes, int, str)
         ), f"{msg +': ' if msg else ''}can't handle arg [{arg}] of type {type(arg)}"
         if isinstance(arg, int):
             assert arg >= 0, f"can't handle negative arguments but was given {arg}"

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -65,5 +65,6 @@ def test_dynamic_array_sum():
     inspector = DryRunExecutor.dryrun_app(
         algod, dyanmic_array_sum_teal, args, abi_arg_types, abi_out_type
     )
-    assert inspector.last_log(has_abi_prefix=True) == 15
-    assert inspector.stack_top(suppress_abi=True) == 1
+    inspector.config(suppress_abi=False, has_abi_prefix=True, force_abi=False)
+    assert inspector.last_log() == 15
+    assert inspector.stack_top() == 1

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -1,0 +1,69 @@
+from algosdk import abi
+
+from graviton.blackbox import DryRunExecutor
+
+from tests.clients import get_algod
+
+dyanmic_array_sum_teal = """#pragma version 6
+txna ApplicationArgs 1      // x = abi.DynamicArray(abi.Uint64TypeSpec())
+store 0                     // 0: x
+load 0                      // [x]
+callsub abisum_0
+store 1
+byte 0x151F7C75
+load 1
+itob
+concat
+log
+int 1
+return
+
+// abi_sum
+abisum_0:                   // [x]
+store 2                     // 2: x
+int 0                       // [0]
+store 3                     // 3: 0
+int 0                       // [0]
+store 4                     // 4: 0
+abisum_0_l1:                // []
+load 4                      
+load 2                      
+int 0                       // [0, x, 0]
+extract_uint16              // [0, len(x)]
+store 6                     // 6: len(x)
+load 6                      // [0, len(x)]
+<                           // [1]
+bz abisum_0_l3              // [0]
+load 2                      // ... looks promising ...
+int 8
+load 4
+*
+int 2
++
+extract_uint64
+store 5
+load 3
+load 5
++
+store 3
+load 4
+int 1
++
+store 4
+b abisum_0_l1
+abisum_0_l3:                // []
+load 3                      // [0]
+retsub
+"""
+
+
+def test_dynamic_array_sum():
+    algod = get_algod()
+    args = ("ignored", [1, 2, 3, 4, 5])
+    abi_arg_types = (None, abi.ArrayDynamicType(abi.UintType(64)))
+    abi_out_type = abi.UintType(64)
+    inspector = DryRunExecutor.dryrun_app(
+        algod, dyanmic_array_sum_teal, args, abi_arg_types, abi_out_type
+    )
+    assert inspector.last_log(has_abi_prefix=True) == 15
+    assert inspector.stack_top(suppress_abi=True) == 1

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -26,8 +26,8 @@ store 3                     // 3: 0
 int 0                       // [0]
 store 4                     // 4: 0
 abisum_0_l1:                // []
-load 4                      
-load 2                      
+load 4
+load 2
 int 0                       // [0, x, 0]
 extract_uint16              // [0, len(x)]
 store 6                     // 6: len(x)

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -65,6 +65,12 @@ def test_dynamic_array_sum():
     inspector = DryRunExecutor.dryrun_app(
         algod, dyanmic_array_sum_teal, args, abi_arg_types, abi_out_type
     )
-    inspector.config(suppress_abi=False, has_abi_prefix=True, force_abi=False)
-    assert inspector.last_log() == 15
-    assert inspector.stack_top() == 1
+    inspector.config(suppress_abi=False, has_abi_prefix=True)
+    assert inspector.last_log() == 15, inspector.report(args, "last log messed up")
+    assert inspector.stack_top() == 1, inspector.report(args, "stack top messed up")
+
+    inspector.config(suppress_abi=True)
+    assert inspector.last_log() == "151f7c75000000000000000f", inspector.report(
+        args, "last log messed up"
+    )
+    assert inspector.stack_top() == 1, inspector.report(args, "stack top messed up")

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -65,11 +65,27 @@ def test_dynamic_array_sum():
     inspector = DryRunExecutor.dryrun_app(
         algod, dyanmic_array_sum_teal, args, abi_arg_types, abi_out_type
     )
+    # with default config:
+    assert inspector.abi_type
+    assert inspector.suppress_abi is False
+    assert inspector.has_abi_prefix is True
+
+    assert inspector.last_log() == 15, inspector.report(args, "last log messed up")
+    assert inspector.stack_top() == 1, inspector.report(args, "stack top messed up")
+
     inspector.config(suppress_abi=False, has_abi_prefix=True)
+    assert inspector.abi_type
+    assert inspector.suppress_abi is False
+    assert inspector.has_abi_prefix is True
+
     assert inspector.last_log() == 15, inspector.report(args, "last log messed up")
     assert inspector.stack_top() == 1, inspector.report(args, "stack top messed up")
 
     inspector.config(suppress_abi=True)
+    assert inspector.abi_type
+    assert inspector.suppress_abi is True
+    assert inspector.has_abi_prefix is True
+
     assert inspector.last_log() == "151f7c75000000000000000f", inspector.report(
         args, "last log messed up"
     )

--- a/tests/unit/encode_test.py
+++ b/tests/unit/encode_test.py
@@ -51,3 +51,27 @@ def test_encode_abi():
     expected = [PyDynArr.encode([1, 3, 5, 7, 9]), (42).to_bytes(8, "big"), "blah"]
     actual = encoder(args, abi_types=[PyDynArr, None, None])
     assert expected == actual
+
+    with pytest.raises(AssertionError) as ae:
+        encoder(args)
+
+    assert (
+        ae.value.args[0]
+        == "problem encoding arg ([1, 3, 5, 7, 9]) at index (0): can't handle arg [[1, 3, 5, 7, 9]] of type <class 'list'>"
+    )
+
+    with pytest.raises(AssertionError) as ae:
+        encoder(args, abi_types=[1, 2, 3, 4])
+
+    assert (
+        ae.value.args[0] == "mismatch between args (length=3) anbd abi_types (length=4)"
+    )
+
+    args = [["wrong", "types", "for", "dynamic", "int", "array"], "blah", "blah"]
+    with pytest.raises(AssertionError) as ae:
+        encoder(args, abi_types=[PyDynArr, None, None])
+
+    assert (
+        ae.value.args[0]
+        == "problem encoding arg (['wrong', 'types', 'for', 'dynamic', 'int', 'array']) at index (0): can't handle arg [['wrong', 'types', 'for', 'dynamic', 'int', 'array']] of type <class 'list'> and abi-type uint64[]: value wrong is not a non-negative int or is too big to fit in size 64"
+    )

--- a/tests/unit/encode_test.py
+++ b/tests/unit/encode_test.py
@@ -1,3 +1,5 @@
+from algosdk.abi import TupleType, BoolType, UintType, ArrayDynamicType
+from pandas import UInt32Dtype, UInt64Dtype
 import pytest
 
 from graviton.blackbox import DryRunEncoder
@@ -9,20 +11,43 @@ def test_encode_arg():
     idx = 17
 
     expected = arg = b"I am bytes I am"
-    assert expected == encoder(arg, idx)
+    assert expected == encoder(arg, idx, None)
 
     expected = arg = "I am a string I am"
-    assert expected == encoder(arg, idx)
+    assert expected == encoder(arg, idx, None)
 
     arg = 42
     expected = arg.to_bytes(8, "big")
-    assert expected == encoder(arg, idx)
+    assert expected == encoder(arg, idx, None)
 
     arg = 42.1337
     with pytest.raises(AssertionError) as ae:
-        encoder(arg, idx)
+        encoder(arg, idx, None)
 
     assert (
         ae.value.args[0]
         == "problem encoding arg (42.1337) at index (17): can't handle arg [42.1337] of type <class 'float'>"
     )
+
+
+def test_encode_abi():
+    encoder = DryRunEncoder.encode_args
+
+    PyInt65 = TupleType(arg_types=[BoolType(), UintType(64)])
+
+    args = [[True, 42], 42, [False, 1339], "I am a string", b"I am bytes I am"]
+    expected = [
+        PyInt65.encode([True, 42]),
+        (42).to_bytes(8, "big"),
+        PyInt65.encode([False, 1339]),
+        "I am a string",
+        b"I am bytes I am",
+    ]
+    actual = encoder(args, abi_types=[PyInt65, None, PyInt65, None, None])
+    assert expected == actual
+
+    PyDynArr = ArrayDynamicType(UintType(64))
+    args = [[1, 3, 5, 7, 9], 42, "blah"]
+    expected = [PyDynArr.encode([1, 3, 5, 7, 9]), (42).to_bytes(8, "big"), "blah"]
+    actual = encoder(args, abi_types=[PyDynArr, None, None])
+    assert expected == actual

--- a/tests/unit/encode_test.py
+++ b/tests/unit/encode_test.py
@@ -63,7 +63,7 @@ def test_encode_abi():
         encoder(args, abi_types=[1, 2, 3, 4])
 
     assert (
-        ae.value.args[0] == "mismatch between args (length=3) anbd abi_types (length=4)"
+        ae.value.args[0] == "mismatch between args (length=3) and abi_types (length=4)"
     )
 
     args = [["wrong", "types", "for", "dynamic", "int", "array"], "blah", "blah"]

--- a/tests/unit/encode_test.py
+++ b/tests/unit/encode_test.py
@@ -34,6 +34,7 @@ def test_encode_abi():
 
     PyInt65 = TupleType(arg_types=[BoolType(), UintType(64)])
 
+    abi_types = [PyInt65, None, PyInt65, None, None]
     args = [[True, 42], 42, [False, 1339], "I am a string", b"I am bytes I am"]
     expected = [
         PyInt65.encode([True, 42]),
@@ -42,13 +43,14 @@ def test_encode_abi():
         "I am a string",
         b"I am bytes I am",
     ]
-    actual = encoder(args, abi_types=[PyInt65, None, PyInt65, None, None])
+    actual = encoder(args, abi_types=abi_types)
     assert expected == actual
 
     PyDynArr = ArrayDynamicType(UintType(64))
+    abi_types = [PyDynArr, None, None]
     args = [[1, 3, 5, 7, 9], 42, "blah"]
     expected = [PyDynArr.encode([1, 3, 5, 7, 9]), (42).to_bytes(8, "big"), "blah"]
-    actual = encoder(args, abi_types=[PyDynArr, None, None])
+    actual = encoder(args, abi_types=abi_types)
     assert expected == actual
 
     with pytest.raises(AssertionError) as ae:

--- a/tests/unit/encode_test.py
+++ b/tests/unit/encode_test.py
@@ -1,0 +1,28 @@
+import pytest
+
+from graviton.blackbox import DryRunEncoder
+
+
+def test_encode_arg():
+    encoder = DryRunEncoder._encode_arg
+
+    idx = 17
+
+    expected = arg = b"I am bytes I am"
+    assert expected == encoder(arg, idx)
+
+    expected = arg = "I am a string I am"
+    assert expected == encoder(arg, idx)
+
+    arg = 42
+    expected = arg.to_bytes(8, "big")
+    assert expected == encoder(arg, idx)
+
+    arg = 42.1337
+    with pytest.raises(AssertionError) as ae:
+        encoder(arg, idx)
+
+    assert (
+        ae.value.args[0]
+        == "problem encoding arg (42.1337) at index (17): can't handle arg [42.1337] of type <class 'float'>"
+    )

--- a/tests/unit/encode_test.py
+++ b/tests/unit/encode_test.py
@@ -1,5 +1,4 @@
 from algosdk.abi import TupleType, BoolType, UintType, ArrayDynamicType
-from pandas import UInt32Dtype, UInt64Dtype
 import pytest
 
 from graviton.blackbox import DryRunEncoder


### PR DESCRIPTION
# Handle ABI types for Graviton Dry Runs


## Summary of Changes
* `CHANGELOG.md` - update with upcoming `v0.2.0` _aka_ 🐗
* `Makefile` - `make all-tests` option
* `graviton/blackbox.py` - 
	* `DryRunEncoder`  - allow specifying `abi_types`  by supplying as a list parameter to `encode_args()` method. When present, the list  needs to be the same length as the `args` being encoded. When `None` is supplied as an `abi_type` the corresponding arg is not encoded.
	* `DryRunExecutor` - allow specifying `abi_argument_types` as well as an `abi_return_type` . `abi_argument_types` are handed off to the `DryRunEncoder` for encoding purposes, while after dry-run execution,  `abi_return_type` is given to the resulting  `DryRunInspector`  for ABI-decoding into Python.
	* `DryRunInspector` - allow specifying an `abi_type`.   When an `abi_type` is provided, `last_log()` will be decoded using that type after removal of a presumed 4-byte return prefix. To suppress removing the 4-byte prefix set `config(has_abi_prefix=False)`. To suppress decoding the last log entry altogether, and show the raw hex, set `config(suppress_abi=True)`.
* `tests/integration/abi_test.py` - new integration test that uses PyTeal generated `sum_abi`  program to sum the array `[1, 2, 3, 4, 5]` and assert that the result is indeed 15
* `tests/unit/encode_test.py` - new unit test for `DryRunEncoder`  