### PR TITLE
Enforce mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ flake8:
 black:
 	black --check .
 
-lint: black flake8
+mypy:
+	mypy .
+
+lint: black flake8 mypy
 
 unit-test:
 	pytest -sv tests/unit

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -235,7 +235,7 @@ class BlackboxResults:
             "steps": self.steps(),
             " top_of_stack": self.final_stack_top() or "",
             "max_stack_height": self.max_stack_height(),
-            **self.final_scratch(with_formatting=True),  # type:ignore
+            **self.final_scratch(with_formatting=True),  # type: ignore
         }
 
 

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -41,7 +41,7 @@ DRProp = DryRunProperty
 
 
 def mode_has_property(mode: ExecutionMode, assertion_type: "DryRunProperty") -> bool:
-    missing = {
+    missing: dict[ExecutionMode, set] = {
         ExecutionMode.Signature: {
             DryRunProperty.cost,
             DryRunProperty.lastLog,
@@ -58,7 +58,7 @@ def mode_has_property(mode: ExecutionMode, assertion_type: "DryRunProperty") -> 
 class TealVal:
     i: int = 0
     b: str = ""
-    is_b: bool = None
+    is_b: Optional[bool] = None
     hide_empty: bool = True
 
     @classmethod
@@ -91,7 +91,7 @@ class BlackboxResults:
     program_counters: List[int]
     teal_line_numbers: List[int]
     teal_source_lines: List[str]
-    stack_evolution: List[list]
+    stack_evolution: List[str]
     scratch_evolution: List[dict]
     final_scratch_state: Dict[int, TealVal]
     slots_used: List[int]
@@ -127,13 +127,14 @@ class BlackboxResults:
         ), f"mismatch of lengths in tls v. stacks ({N} v. {len(stacks)})"
 
         # process scratch var's
-        scratches = [
+        def list_scratches() -> list[list[TealVal]]:
+            return [
             [TealVal.from_scratch(s) for s in x]
             for x in [t.get("scratch", []) for t in trace]
         ]
-        scratches = [
+        scratches: List[Dict[int, TealVal]] = [
             {i: s for i, s in enumerate(scratch) if not s.is_empty()}
-            for scratch in scratches
+            for scratch in list_scratches()
         ]
         slots_used = sorted(set().union(*(s.keys() for s in scratches)))
         final_scratch_state = scratches[-1]

--- a/graviton/dryrun.py
+++ b/graviton/dryrun.py
@@ -2,7 +2,7 @@ import base64
 import binascii
 from dataclasses import dataclass
 import string
-from typing import List, Union
+from typing import List, Optional, Union
 
 from algosdk.constants import payment_txn, appcall_txn
 from algosdk.future import transaction
@@ -26,7 +26,7 @@ PRINTABLE = frozenset(string.printable)
 class LSig:
     """Logic Sig program parameters"""
 
-    args: List[bytes] = None
+    args: Optional[List[bytes]] = None
 
 
 @dataclass
@@ -34,12 +34,12 @@ class App:
     """Application program parameters"""
 
     creator: str = ZERO_ADDRESS
-    round: int = None
+    round: Optional[int] = None
     app_idx: int = 0
     on_complete: int = 0
-    args: List[bytes] = None
-    accounts: List[Union[str, Account]] = None
-    global_state: List[TealKeyValue] = None
+    args: Optional[List[bytes]] = None
+    accounts: Optional[List[Union[str, Account]]] = None
+    global_state: Optional[List[TealKeyValue]] = None
 
 
 # ### LIGHTWEIGHT ASSERTIONS FOR RE-USE ### #

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -98,7 +98,7 @@ class Invariant:
         raw_predicates: bool = False,
     ) -> Tuple[List[tuple], Dict[DryRunProperty, Any]]:
         """
-        Validate that a Blackbox Test Scenario has been properly constructed, and return back
+        Validate that a Blackbox Test Scenario has been properly constructed, and returns back
         its components which consist of **inputs** and _optional_ **invariants**.
 
         A scenario should adhere to the following schema:
@@ -108,7 +108,7 @@ class Invariant:
             "invariants":   Dict[DryRuninvariantType, ...an invariant...]
         }
 
-        Each invariants is a map from a _dryrun property_ to assert about
+        Each invariant is a map from a _dryrun property_ to assert about
         to the actual invariant. Actual invariants can be:
         * simple python types - these are useful in the case of _constant_ invariants.
             For example, if you want to assert that the `maxStackHeight` is 3, just use `3`.
@@ -150,6 +150,6 @@ class Invariant:
                 assert isinstance(key, DryRunProperty) and mode_has_property(
                     mode, key
                 ), f"each key must be a DryRunProperty's appropriate to {mode}. This is not the case for key {key}"
-                invariants[key] = Invariant(predicate, name=key)
+                invariants[key] = Invariant(predicate, name=str(key))
 
-        return inputs, predicates if raw_predicates else invariants
+        return inputs, predicates if raw_predicates else invariants  # type: ignore

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy-pytest.*]
+ignore_missing_imports = True
+
+[mypy-algosdk.*]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,10 @@
+[mypy]
+
+[mypy-algosdk.*]
+ignore_missing_imports = True
+
 [mypy-pytest.*]
 ignore_missing_imports = True
 
-[mypy-algosdk.*]
+[mypy-setuptools.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,15 @@ setup(
     author_email="pypiservice@algorand.com",
     python_requires=">=3.8",
     install_requires=["py-algorand-sdk", "tabulate==0.8.9"],
-    extras_require={"development": [
-        "black==22.3.0",
-        "flake8==4.0.1",
-        "mypy==0.950",
-        "pytest==7.1.1",
-        "types-tabulate==0.8.9"
-    ]},
+    extras_require={
+        "development": [
+            "black==22.3.0",
+            "flake8==4.0.1",
+            "mypy==0.950",
+            "pytest==7.1.1",
+            "types-tabulate==0.8.9",
+        ]
+    },
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,13 @@ setup(
     author_email="pypiservice@algorand.com",
     python_requires=">=3.8",
     install_requires=["py-algorand-sdk", "tabulate==0.8.9"],
-    extras_require={"development": ["pytest==7.1.1", "black==22.3.0", "flake8==4.0.1"]},
+    extras_require={"development": [
+        "black==22.3.0",
+        "flake8==4.0.1",
+        "mypy==0.950",
+        "pytest==7.1.1",
+        "types-tabulate==0.8.9"
+    ]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -70,6 +70,7 @@ def test_dynamic_array_sum():
     assert inspector.suppress_abi is False
     assert inspector.has_abi_prefix is True
 
+    print(inspector.last_log())
     assert inspector.last_log() == 15, inspector.report(args, "last log messed up")
     assert inspector.stack_top() == 1, inspector.report(args, "stack top messed up")
 

--- a/tests/integration/blackbox_test.py
+++ b/tests/integration/blackbox_test.py
@@ -351,7 +351,7 @@ def test_app_with_report(filebase: str):
 
     # 0. Validate that the scenarios are well defined:
     inputs, invariants = Invariant.inputs_and_invariants(
-        scenario, mode, raw_predicates=True
+        scenario, mode, raw_predicates=True  # type: ignore
     )
 
     algod = get_algod()
@@ -371,7 +371,7 @@ def test_app_with_report(filebase: str):
     )
 
     # 2. Run the requests to obtain sequence of Dryrun responses:
-    dryrun_results = Executor.dryrun_app_on_sequence(algod, teal, inputs)
+    dryrun_results = Executor.dryrun_app_on_sequence(algod, teal, inputs)  # type: ignore
 
     # 3. Generate statistical report of all the runs:
     csvpath = path / f"{filebase}.csv"
@@ -543,7 +543,7 @@ def test_logicsig_with_report(filebase: str):
 
     # 0. Validate that the scenarios are well defined:
     inputs, invariants = Invariant.inputs_and_invariants(
-        scenario, mode, raw_predicates=True
+        scenario, mode, raw_predicates=True  # type: ignore
     )
 
     algod = get_algod()
@@ -563,7 +563,7 @@ def test_logicsig_with_report(filebase: str):
     )
 
     # 2. Run the requests to obtain sequence of Dryrun resonses:
-    dryrun_results = Executor.dryrun_logicsig_on_sequence(algod, teal, inputs)
+    dryrun_results = Executor.dryrun_logicsig_on_sequence(algod, teal, inputs)  # type: ignore
 
     # 3. Generate statistical report of all the runs:
     csvpath = path / f"{filebase}.csv"


### PR DESCRIPTION
Enforces _mypy_ throughout the repo making a best-effort attempt to remediate mypy errors.

The PR adds `# type: ignore` in several places as a workaround.  In these cases, I was unable to remediate the mypy error in a way that preserved tests.  I welcome feedback or alternative suggestions.