### PR TITLE
ABI Method / Routing / Contract functionality

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-ignore = E501, W503
+ignore = E203, E501, W503

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     container: python:${{ matrix.python }}
     strategy:
       matrix:
-        python: [ "3.8", "3.9", "3.10" ]
+        python: [ "3.9", "3.10" ]
     steps:
       - run: python3 --version
       - name: Check out code
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python: [ "3.8", "3.9", "3.10" ]
+        python: [ "3.9", "3.10" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 * A bug that made all app calls run as if during creation
 * Addressed [Issue #5](https://github.com/algorand/graviton/issues/5): Better assertion message for invariant predicates of 2 variables
 
+### Upgraded
+
+* Minimum python is bumped up to 3.9 (previously 3.8)
+
 ## `v0.3.0` (_aka_ 🐈)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 * A bug that made all app calls run as if during creation
+* Addressed [Issue #5](https://github.com/algorand/graviton/issues/5): Better assertion message for invariant predicates of 2 variables
 
 ## `v0.3.0` (_aka_ 🐈)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## `v0.4.0` (_aka_ 🐕)
+
+### Added
+
+* ABI Contract / Router / Execution functionality
+
+### Fixed
+
+* A bug that made all app calls run as if during creation
+
 ## `v0.3.0` (_aka_ 🐈)
 
 ### Added
@@ -13,7 +23,7 @@
 
 ### Added
 
-* ABI Functionality
+* ABI Functionality (types only)
 
 ## `v0.1.2`
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ flake8:
 	flake8 graviton tests
 
 mypy:
-	mypy .
+	mypy --show-error-codes .
 
 lint: black flake8 mypy
 

--- a/graviton/abi_strategy.py
+++ b/graviton/abi_strategy.py
@@ -3,6 +3,7 @@ Inspired by Hypothesis' Strategies.
 
 TODO: Leverage Hypothesis!
 """
+from abc import ABC, abstractmethod
 from collections import OrderedDict
 import random
 import string
@@ -13,7 +14,20 @@ from algosdk import abi, encoding
 PY_TYPES = Union[bool, int, list, str, bytes]
 
 
-class ABIStrategy:
+class ABIStrategy(ABC):
+    @abstractmethod
+    def __init__(self, abi_instance: abi.ABIType, dynamic_length: Optional[int] = None):
+        pass
+
+    @abstractmethod
+    def get(self) -> PY_TYPES:
+        pass
+
+    def get_many(self, n: int) -> List[PY_TYPES]:
+        return [self.get() for _ in range(n)]
+
+
+class RandomABIStrategy(ABIStrategy):
     DEFAULT_DYNAMIC_ARRAY_LENGTH = 3
     STRING_CHARS = string.digits + string.ascii_letters + string.punctuation
 
@@ -46,7 +60,7 @@ class ABIStrategy:
         self.abi_type: abi.ABIType = abi_instance
         self.dynamic_length: Optional[int] = dynamic_length
 
-    def get_random(self) -> Union[bool, int, list, str, bytes]:
+    def get(self) -> PY_TYPES:
         if isinstance(self.abi_type, abi.UfixedType):
             raise NotImplementedError(
                 f"Currently cannot get a random sample for {self.abi_type}"
@@ -59,17 +73,17 @@ class ABIStrategy:
             return random.randint(0, (1 << self.abi_type.bit_size) - 1)
 
         if isinstance(self.abi_type, abi.ByteType):
-            return ABIStrategy(abi.UintType(8)).get_random()
+            return RandomABIStrategy(abi.UintType(8)).get()
 
         if isinstance(self.abi_type, abi.TupleType):
             return [
-                ABIStrategy(child_type).get_random()
+                RandomABIStrategy(child_type).get()
                 for child_type in self.abi_type.child_types
             ]
 
         if isinstance(self.abi_type, abi.ArrayStaticType):
             return [
-                ABIStrategy(self.abi_type.child_type).get_random()
+                RandomABIStrategy(self.abi_type.child_type).get()
                 for _ in range(self.abi_type.static_length)
             ]
 
@@ -78,11 +92,11 @@ class ABIStrategy:
                 bytearray(
                     cast(
                         List[int],
-                        ABIStrategy(
+                        RandomABIStrategy(
                             abi.ArrayStaticType(
                                 abi.ByteType(), self.abi_type.byte_len()
                             )
-                        ).get_random(),
+                        ).get(),
                     )
                 )
             )
@@ -94,8 +108,7 @@ class ABIStrategy:
         )
         if isinstance(self.abi_type, abi.ArrayDynamicType):
             return [
-                ABIStrategy(self.abi_type.child_type).get_random()
-                for _ in dynamic_range
+                RandomABIStrategy(self.abi_type.child_type).get() for _ in dynamic_range
             ]
 
         if isinstance(self.abi_type, abi.StringType):
@@ -125,7 +138,7 @@ class ABIStrategy:
             y = encoding.decode_address(x)
             return encoding.encode_address(
                 bytearray(
-                    ABIStrategy(
+                    RandomABIStrategy(
                         abi.ArrayStaticType(abi.ByteType(), len(y))
                     ).mutate_for_roundtrip(y)
                 )
@@ -138,19 +151,23 @@ class ABIStrategy:
                 (abi.UintType, lambda x: (1 << self.abi_type.bit_size) - 1 - x),
                 (
                     abi.ByteType,
-                    lambda x: ABIStrategy(abi.UintType(8)).mutate_for_roundtrip(x),
+                    lambda x: RandomABIStrategy(abi.UintType(8)).mutate_for_roundtrip(
+                        x
+                    ),
                 ),
                 (
                     abi.TupleType,
                     lambda x: [
-                        ABIStrategy(child_type).mutate_for_roundtrip(x[i])
+                        RandomABIStrategy(child_type).mutate_for_roundtrip(x[i])
                         for i, child_type in enumerate(self.abi_type.child_types)
                     ],
                 ),
                 (
                     abi.ArrayStaticType,
                     lambda x: [
-                        ABIStrategy(self.abi_type.child_type).mutate_for_roundtrip(y)
+                        RandomABIStrategy(
+                            self.abi_type.child_type
+                        ).mutate_for_roundtrip(y)
                         for y in x
                     ],
                 ),
@@ -158,7 +175,9 @@ class ABIStrategy:
                 (
                     abi.ArrayDynamicType,
                     lambda x: [
-                        ABIStrategy(self.abi_type.child_type).mutate_for_roundtrip(y)
+                        RandomABIStrategy(
+                            self.abi_type.child_type
+                        ).mutate_for_roundtrip(y)
                         for y in x
                     ],
                 ),

--- a/graviton/abi_strategy.py
+++ b/graviton/abi_strategy.py
@@ -16,10 +16,6 @@ PY_TYPES = Union[bool, int, Sequence, str, bytes]
 
 class ABIStrategy(ABC):
     @abstractmethod
-    def __init__(self, abi_instance: abi.ABIType, dynamic_length: Optional[int] = None):
-        pass
-
-    @abstractmethod
     def get(self) -> PY_TYPES:
         pass
 

--- a/graviton/abi_strategy.py
+++ b/graviton/abi_strategy.py
@@ -7,11 +7,11 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 import random
 import string
-from typing import Callable, Dict, List, Optional, Union, cast
+from typing import Callable, Dict, List, Optional, Sequence, Union, cast
 
 from algosdk import abi, encoding
 
-PY_TYPES = Union[bool, int, list, str, bytes]
+PY_TYPES = Union[bool, int, Sequence, str, bytes]
 
 
 class ABIStrategy(ABC):
@@ -187,3 +187,20 @@ class RandomABIStrategy(ABIStrategy):
         )
 
         return self.map(waterfall, py_abi_instance)
+
+
+class RandomABIStrategyHalfSized(RandomABIStrategy):
+    def __init__(
+        self,
+        abi_instance: abi.ABIType,
+        dynamic_length: Optional[int] = None,
+    ):
+        super().__init__(abi_instance, dynamic_length=dynamic_length)
+
+    def get(self) -> PY_TYPES:
+        full_random = super().get()
+
+        if not isinstance(self.abi_type, abi.UintType):
+            return full_random
+
+        return full_random % (1 << (self.abi_type.bit_size // 2))

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -762,10 +762,10 @@ class ABIContractExecutor:
         """ARC-4 Compliant Dry Run"""
         # TODO: handle txn_params
 
-        if not arg_types:
+        if arg_types is None:
             arg_types = self.argument_types(method)
 
-        if not return_type:
+        if return_type is None:
             return_type = self.return_type(method)
 
         if inputs is None:

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -398,11 +398,11 @@ class DryRunExecutor:
     """
 
     # `CREATION_APP_CALL` and `EXISTING_APP_CALL` are enum-like constants used to denote whether a dry run
-    # execution will simulate calling during on-creation vs pre-existance.
+    # execution will simulate calling during on-creation vs post-creation.
     # In the default case that a dry run is executed without a provided application id (aka `index`), the `index`
     # supplied will be:
-    # * `EXISTING_APP_CALL` in the case of `is_app_create == False`
     # * `CREATION_APP_CALL` in the case of `is_app_create == True`
+    # * `EXISTING_APP_CALL` in the case of `is_app_create == False`
     CREATION_APP_CALL: Final[int] = 0
     EXISTING_APP_CALL: Final[int] = 42
 

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -582,6 +582,12 @@ class DryRunExecutor:
         return {k: v for k, v in params.items() if v is not None}
 
 
+class ABIContractExecutor:
+    def __init__(self, teal: str, contract: str):
+        self.program = teal
+        self.contract: abi.Contract = abi.Contract.from_json(contract)
+
+
 class DryRunInspector:
     """Methods to extract information from a single dry run transaction.
 

--- a/graviton/dryrun.py
+++ b/graviton/dryrun.py
@@ -214,7 +214,13 @@ class DryRunHelper:
     def singleton_app_request(
         cls, program: str, args: List[Union[bytes, str]], txn_params: Dict[str, Any]
     ):
-        return cls.dryrun_request(program, models.App(args=args), txn_params)
+        creator = txn_params.get("sender")
+        app_idx = txn_params.get("index")
+        on_complete = txn_params.get("on_complete")
+        app = models.App.factory(
+            creator=creator, app_idx=app_idx, on_complete=on_complete, args=args
+        )
+        return cls.dryrun_request(program, app, txn_params)
 
     @classmethod
     def _txn_params_with_defaults(cls, txn_params: dict, for_app: bool) -> dict:

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -1,6 +1,7 @@
 from inspect import signature
 from typing import cast, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
+from graviton.abi_strategy import PY_TYPES
 from graviton.blackbox import (
     DryRunInspector,
     DryRunProperty,
@@ -26,41 +27,32 @@ class Invariant:
     def __repr__(self):
         return f"Invariant({self.definition})"[:100]
 
-    def __call__(
-        self, args: Sequence[Union[str, int]], actual: Union[str, int]
-    ) -> Tuple[bool, str]:
+    def __call__(self, args: Sequence[PY_TYPES], actual: PY_TYPES) -> Tuple[bool, str]:
         invariant = self.predicate(args, actual)
         msg = ""
         if not invariant:
-            msg = f"Invariant for '{self.name}' failed for for args {args}: actual is [{actual}] BUT expected [{self.expected(args)}]"
+            msg = f"Invariant for '{self.name}' failed for for args {args!r}: actual is [{actual!r}] BUT expected [{self.expected(args)!r}]"
             if self.enforce:
                 assert invariant, msg
 
         return invariant, msg
 
-    def expected(self, args: Sequence[Union[str, int]]) -> Union[str, int]:
+    def expected(self, args: Sequence[PY_TYPES]) -> PY_TYPES:
         return self._expected(args)
 
     def validates(
         self,
         dr_property: DryRunProperty,
-        inputs: List[Sequence[Union[str, int]]],
         inspectors: List[DryRunInspector],
     ):
-        N = len(inputs)
-        assert N == len(
-            inspectors
-        ), f"inputs (len={N}) and dryrun responses (len={len(inspectors)}) must have the same length"
-
         assert isinstance(
             dr_property, DryRunProperty
         ), f"invariants types must be DryRunProperty's but got [{dr_property}] which is a {type(dr_property)}"
 
-        for i, args in enumerate(inputs):
-            res = inspectors[i]
-            actual = res.dig(dr_property)
-            ok, msg = self(args, actual)
-            assert ok, res.report(args, msg, row=i + 1)
+        for i, inspector in enumerate(inspectors):
+            actual = inspector.dig(dr_property)
+            ok, msg = self(inspector.args, actual)
+            assert ok, inspector.report(msg=msg, row=i + 1)
 
     @classmethod
     def prepare_predicate(cls, predicate):
@@ -140,15 +132,25 @@ class Invariant:
             and all(isinstance(args, tuple) for args in inputs)
         ), "need a list of inputs with at least one args and all args must be tuples"
 
-        invariants: Dict[DryRunProperty, Any] = {}
         predicates = cast(Dict[DryRunProperty, Any], scenario.get("invariants", {}))
         if predicates:
             assert isinstance(predicates, dict), "invariants must be a dict"
 
-            for key, predicate in predicates.items():
-                assert isinstance(key, DryRunProperty) and mode_has_property(
-                    mode, key
-                ), f"each key must be a DryRunProperty's appropriate to {mode}. This is not the case for key {key}"
-                invariants[key] = Invariant(predicate, name=str(key))
+        return inputs, predicates if raw_predicates else cls.as_invariants(
+            predicates, mode
+        )
 
-        return inputs, predicates if raw_predicates else invariants  # type: ignore
+    @classmethod
+    def as_invariants(
+        cls,
+        predicates: Dict[DryRunProperty, Any],
+        mode: ExecutionMode = ExecutionMode.Application,
+    ) -> Dict[DryRunProperty, "Invariant"]:
+        invariants: Dict[DryRunProperty, Any] = {}
+
+        for key, predicate in predicates.items():
+            assert isinstance(key, DryRunProperty) and mode_has_property(
+                mode, key
+            ), f"each key must be a DryRunProperty's appropriate to {mode}. This is not the case for key {key}"
+            invariants[key] = Invariant(predicate, name=str(key))
+        return invariants

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -1,4 +1,4 @@
-from inspect import signature
+from inspect import getsource, signature
 from typing import cast, Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from graviton.abi_strategy import PY_TYPES
@@ -10,12 +10,20 @@ from graviton.blackbox import (
 )
 
 
+INVARIANT_TYPE = Union[
+    PY_TYPES,
+    Dict[Sequence[PY_TYPES], PY_TYPES],
+    Callable[[PY_TYPES], PY_TYPES],
+    Callable[[PY_TYPES], bool],
+]
+
+
 class Invariant:
     """Enable asserting invariants on a sequence of dry run executions"""
 
     def __init__(
         self,
-        predicate: Union[Dict[Tuple, Union[str, int]], Callable],
+        predicate: INVARIANT_TYPE,
         enforce: bool = False,
         name: Optional[str] = None,
     ):
@@ -31,7 +39,10 @@ class Invariant:
         invariant = self.predicate(args, actual)
         msg = ""
         if not invariant:
-            msg = f"Invariant for '{self.name}' failed for for args {args!r}: actual is [{actual!r}] BUT expected [{self.expected(args)!r}]"
+            expected = self.expected(args)
+            if callable(expected):
+                expected = getsource(expected)
+            msg = f"Invariant for '{self.name}' failed for for args {args!r}: actual is [{actual!r}] BUT expected [{expected!r}]"
             if self.enforce:
                 assert invariant, msg
 
@@ -44,6 +55,8 @@ class Invariant:
         self,
         dr_property: DryRunProperty,
         inspectors: List[DryRunInspector],
+        *,
+        msg: str = "",
     ):
         assert isinstance(
             dr_property, DryRunProperty
@@ -51,18 +64,31 @@ class Invariant:
 
         for i, inspector in enumerate(inspectors):
             actual = inspector.dig(dr_property)
-            ok, msg = self(inspector.args, actual)
-            assert ok, inspector.report(msg=msg, row=i + 1)
+            ok, fail_msg = self(inspector.args, actual)
+            if msg:
+                fail_msg += f". invariant provided message:{msg}"
+            assert ok, inspector.report(msg=fail_msg, row=i + 1)
 
     @classmethod
-    def prepare_predicate(cls, predicate):
+    def prepare_predicate(
+        cls,
+        predicate: INVARIANT_TYPE,
+    ) -> Tuple[Callable[[Sequence[PY_TYPES], PY_TYPES], bool], Callable]:
+        # returns
+        # * Callable[[Sequence[PY_TYPES], PY_TYPES], bool]
+        # * Callable[[Sequence[PY_TYPES]], PY_TYPES]
         if isinstance(predicate, dict):
+            d_predicate = cast(Dict[PY_TYPES, PY_TYPES], predicate)
             return (
-                lambda args, actual: predicate[args] == actual,
-                lambda args: predicate[args],
+                lambda args, actual: d_predicate[args] == actual,
+                lambda args: d_predicate[args],
             )
 
-        if not isinstance(predicate, Callable):
+        # predicate = cast(Callable, predicate)
+        # returns
+        # * Callable[[Any], PY_TYPES], bool]
+        # * Callable[[Any], PY_TYPES]
+        if not callable(predicate):
             # constant function in this case:
             return lambda _, actual: predicate == actual, lambda _: predicate
 
@@ -77,12 +103,22 @@ class Invariant:
         assert N in (1, 2), f"predicate has the wrong number of paramters {N}"
 
         if N == 2:
-            return predicate, lambda _: predicate
+            c2_predicate = cast(
+                Callable[[Sequence[PY_TYPES], PY_TYPES], bool], predicate
+            )
+            # returns
+            # * Callable[[Sequence[PY_TYPES], PY_TYPES], bool]
+            # * Callable[Any, Callable[[Sequence[PY_TYPES], PY_TYPES], bool]]
+            return c2_predicate, lambda _: c2_predicate
 
         # N == 1:
-        return lambda args, actual: predicate(args) == actual, lambda args: predicate(
+        c1_predicate = cast(Callable[[Sequence[PY_TYPES]], bool], predicate)
+        # returns
+        # * Callable[[Sequence[PY_TYPES]], bool]
+        # * Callable[[Sequence[PY_TYPES]], PY_TYPES]
+        return lambda args, actual: c1_predicate(
             args
-        )
+        ) == actual, lambda args: c1_predicate(args)
 
     @classmethod
     def inputs_and_invariants(

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -33,7 +33,11 @@ class Invariant:
         self.name = name
 
     def __repr__(self):
-        return f"Invariant({self.definition})"[:100]
+        defn = self.definition
+        if callable(defn):
+            defn = getsource(defn)
+
+        return f"Invariant({defn})"
 
     def __call__(self, args: Sequence[PY_TYPES], actual: PY_TYPES) -> Tuple[bool, str]:
         invariant = self.predicate(args, actual)

--- a/graviton/models.py
+++ b/graviton/models.py
@@ -38,3 +38,11 @@ class App:
     args: Optional[List[Union[bytes, str]]] = None
     accounts: Optional[List[Union[str, Account]]] = None
     global_state: Optional[List[TealKeyValue]] = None
+
+    @classmethod
+    def factory(cls, **kwargs) -> "App":
+        app = cls()
+        for key, val in kwargs.items():
+            if hasattr(app, key) and val is not None:
+                setattr(app, key, val)
+        return app

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,7 @@ setup(
     author="Algorand",
     author_email="pypiservice@algorand.com",
     python_requires=">=3.9",
-    install_requires=[
-        "py-algorand-sdk @ git+https://github.com/algorand/py-algorand-sdk@develop",
-        "tabulate==0.8.9",
-    ],
+    install_requires=["py-algorand-sdk==1.15.0", "tabulate==0.8.9"],
     extras_require={
         "development": [
             "black==22.3.0",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ setup(
     author="Algorand",
     author_email="pypiservice@algorand.com",
     python_requires=">=3.8",
-    install_requires=["py-algorand-sdk", "tabulate==0.8.9"],
+    install_requires=[
+        "py-algorand-sdk @ git+https://github.com/algorand/py-algorand-sdk@get-method-by-name",
+        "tabulate==0.8.9",
+    ],
     extras_require={
         "development": [
             "black==22.3.0",

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     long_description=long_description,
     author="Algorand",
     author_email="pypiservice@algorand.com",
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=[
         "py-algorand-sdk @ git+https://github.com/algorand/py-algorand-sdk@get-method-by-name",
         "tabulate==0.8.9",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email="pypiservice@algorand.com",
     python_requires=">=3.9",
     install_requires=[
-        "py-algorand-sdk @ git+https://github.com/algorand/py-algorand-sdk@get-method-by-name",
+        "py-algorand-sdk @ git+https://github.com/algorand/py-algorand-sdk@develop",
         "tabulate==0.8.9",
     ],
     extras_require={

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -19,7 +19,7 @@ import pytest
 
 from algosdk import abi
 
-from graviton.blackbox import DryRunExecutor, DryRunEncoder
+from graviton.blackbox import ABIContractExecutor, DryRunExecutor, DryRunEncoder
 from graviton.abi_strategy import ABIStrategy
 
 from tests.clients import get_algod
@@ -222,3 +222,17 @@ mut_mut = {mut_mut}
     assert expected_mut == mut, inspector.report(
         args, "expected_mut v. mut", last_steps=last_rows
     )
+
+
+ROUTER = Path.cwd() / "tests" / "teal" / "router"
+
+
+def test_abi_methods():
+    with open(ROUTER / "questionable.json") as f:
+        contract = f.read()
+
+    with open(ROUTER / "questionable.teal") as f:
+        teal = f.read()
+
+    ace = ABIContractExecutor(teal, contract)
+    x = 42

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -394,9 +394,6 @@ NEGATIVE_INVARIANTS = Invariant.as_invariants(
 )
 
 
-temporarily_skip_iia = True
-
-
 @pytest.mark.parametrize("method, call_types, _", QUESTIONABLE_CASES)
 def test_method_or_barecall_negative(method, call_types, _):
     """
@@ -473,12 +470,11 @@ invariant={invariant}"""
 
     for is_app_create, on_complete in call_types:
         scenario = "II(a). adding an extra duplicate argument"
-        if not temporarily_skip_iia:
-            inspectors = dry_runner(
-                inputs=extra_arg, validate_inputs=False, arg_types=extra_arg_types
-            )
-            for dr_prop, invariant in NEGATIVE_INVARIANTS.items():
-                invariant.validates(dr_prop, inspectors, msg=msg())
+        inspectors = dry_runner(
+            inputs=extra_arg, validate_inputs=False, arg_types=extra_arg_types
+        )
+        for dr_prop, invariant in NEGATIVE_INVARIANTS.items():
+            invariant.validates(dr_prop, inspectors, msg=msg())
 
         if missing_arg:
             scenario = "II(b). removing the final argument"

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -650,7 +650,7 @@ invariant={invariant}"""
 
 # ---- ABI Router Dry Run Testing - TESTS ---- #
 
-### QUESTIONABLE ###
+# ## QUESTIONABLE ## #
 
 
 @pytest.mark.parametrize("method, call_types, invariants", QUESTIONABLE_CASES)
@@ -685,7 +685,7 @@ def test_questionable_clear_program_method_or_barecall_negative(method, call_typ
     )
 
 
-### YACC (QUESTIONABLE Copy Pasta 🍝)###
+# ## YACC (QUESTIONABLE Copy Pasta 🍝) ## #
 
 
 @pytest.mark.parametrize("method, call_types, invariants", YACC_CASES)

--- a/tests/integration/blackbox_test.py
+++ b/tests/integration/blackbox_test.py
@@ -383,7 +383,7 @@ def test_app_with_report(filebase: str):
         print(
             f"{i+1}. Semantic invariant for {case_name}-{mode}: {dr_property} <<{invariant}>>"
         )
-        invariant.validates(dr_property, inputs, dryrun_results)
+        invariant.validates(dr_property, dryrun_results)
 
 
 # NOTE: logic sig dry runs are missing some information when compared with app dry runs.
@@ -575,4 +575,4 @@ def test_logicsig_with_report(filebase: str):
         print(
             f"{i+1}. Semantic invariant for {case_name}-{mode}: {dr_property} <<{invariant}>>"
         )
-        invariant.validates(dr_property, inputs, dryrun_results)
+        invariant.validates(dr_property, dryrun_results)

--- a/tests/integration/blackbox_test.py
+++ b/tests/integration/blackbox_test.py
@@ -206,11 +206,7 @@ APP_SCENARIOS = {
         "inputs": [(i,) for i in range(100)],
         "invariants": {
             DRProp.cost: 14,
-            DRProp.lastLog: {
-                # since execution REJECTS for 0, expect last log for this case to be None
-                (i,): Encoder.hex(i * i) if i else None
-                for i in range(100)
-            },
+            DRProp.lastLog: {(i,): Encoder.hex(i * i) for i in range(100)},
             DRProp.finalScratch: lambda args: (
                 {0: args[0], 1: args[0] ** 2} if args[0] else {}
             ),
@@ -247,9 +243,7 @@ APP_SCENARIOS = {
         "inputs": [("xyzw", i) for i in range(100)],
         "invariants": {
             DRProp.cost: lambda args: 30 + 15 * args[1],
-            DRProp.lastLog: (
-                lambda args: Encoder.hex(args[0] * args[1]) if args[1] else None
-            ),
+            DRProp.lastLog: (lambda args: Encoder.hex(args[0] * args[1])),
             # due to dryrun 0-scratchvar artifact, special case for i == 0:
             DRProp.finalScratch: lambda args: (
                 {
@@ -308,7 +302,7 @@ APP_SCENARIOS = {
         "invariants": {
             DRProp.cost: lambda args: (fib_cost(args) if args[0] < 17 else 70_000),
             DRProp.lastLog: lambda args: (
-                Encoder.hex(fib(args[0])) if 0 < args[0] < 17 else None
+                Encoder.hex(fib(args[0])) if args[0] < 17 else None
             ),
             DRProp.finalScratch: lambda args, actual: (
                 actual == {0: args[0], 1: fib(args[0])}

--- a/tests/integration/doc_examples_test.py
+++ b/tests/integration/doc_examples_test.py
@@ -179,7 +179,7 @@ def test_step9():
 
     # Invariant assertions on sequence:
     for dr_property, invariant in invariants.items():
-        invariant.validates(dr_property, inputs, inspectors)
+        invariant.validates(dr_property, inspectors)
 
 
 @pytest.mark.parametrize("exercise", ["A", "B"])
@@ -218,4 +218,4 @@ def test_exercises(exercise):
 
     # Invariant assertions on sequence:
     for dr_property, invariant in invariants.items():
-        invariant.validates(dr_property, inputs, inspectors)
+        invariant.validates(dr_property, inspectors)

--- a/tests/teal/router/questionable.json
+++ b/tests/teal/router/questionable.json
@@ -1,0 +1,192 @@
+{
+  "name": "ASimpleQuestionablyRobustContract",
+  "methods": [
+    {
+      "name": "add",
+      "args": [
+        {
+          "type": "uint64",
+          "name": "a"
+        },
+        {
+          "type": "uint64",
+          "name": "b"
+        }
+      ],
+      "returns": {
+        "type": "uint64"
+      }
+    },
+    {
+      "name": "sub",
+      "args": [
+        {
+          "type": "uint64",
+          "name": "a"
+        },
+        {
+          "type": "uint64",
+          "name": "b"
+        }
+      ],
+      "returns": {
+        "type": "uint64"
+      }
+    },
+    {
+      "name": "mul",
+      "args": [
+        {
+          "type": "uint64",
+          "name": "a"
+        },
+        {
+          "type": "uint64",
+          "name": "b"
+        }
+      ],
+      "returns": {
+        "type": "uint64"
+      }
+    },
+    {
+      "name": "div",
+      "args": [
+        {
+          "type": "uint64",
+          "name": "a"
+        },
+        {
+          "type": "uint64",
+          "name": "b"
+        }
+      ],
+      "returns": {
+        "type": "uint64"
+      }
+    },
+    {
+      "name": "mod",
+      "args": [
+        {
+          "type": "uint64",
+          "name": "a"
+        },
+        {
+          "type": "uint64",
+          "name": "b"
+        }
+      ],
+      "returns": {
+        "type": "uint64"
+      }
+    },
+    {
+      "name": "all_laid_to_args",
+      "args": [
+        {
+          "type": "uint64",
+          "name": "_a"
+        },
+        {
+          "type": "uint64",
+          "name": "_b"
+        },
+        {
+          "type": "uint64",
+          "name": "_c"
+        },
+        {
+          "type": "uint64",
+          "name": "_d"
+        },
+        {
+          "type": "uint64",
+          "name": "_e"
+        },
+        {
+          "type": "uint64",
+          "name": "_f"
+        },
+        {
+          "type": "uint64",
+          "name": "_g"
+        },
+        {
+          "type": "uint64",
+          "name": "_h"
+        },
+        {
+          "type": "uint64",
+          "name": "_i"
+        },
+        {
+          "type": "uint64",
+          "name": "_j"
+        },
+        {
+          "type": "uint64",
+          "name": "_k"
+        },
+        {
+          "type": "uint64",
+          "name": "_l"
+        },
+        {
+          "type": "uint64",
+          "name": "_m"
+        },
+        {
+          "type": "uint64",
+          "name": "_n"
+        },
+        {
+          "type": "uint64",
+          "name": "_o"
+        },
+        {
+          "type": "uint64",
+          "name": "_p"
+        }
+      ],
+      "returns": {
+        "type": "uint64"
+      }
+    },
+    {
+      "name": "empty_return_subroutine",
+      "args": [],
+      "returns": {
+        "type": "void"
+      }
+    },
+    {
+      "name": "log_1",
+      "args": [],
+      "returns": {
+        "type": "uint64"
+      }
+    },
+    {
+      "name": "log_creation",
+      "args": [],
+      "returns": {
+        "type": "string"
+      }
+    },
+    {
+      "name": "approve_if_odd",
+      "args": [
+        {
+          "type": "uint32",
+          "name": "condition_encoding"
+        }
+      ],
+      "returns": {
+        "type": "void"
+      }
+    }
+  ],
+  "desc": null,
+  "networks": {}
+}

--- a/tests/teal/router/questionable.teal
+++ b/tests/teal/router/questionable.teal
@@ -292,7 +292,7 @@ return
 main_l19:
 txn OnCompletion
 int NoOp
-==
+==                      // I believe there ahould be an assertion here to ensure that this is actually a NoOp
 txn ApplicationID
 int 0
 !=

--- a/tests/teal/router/questionable.teal
+++ b/tests/teal/router/questionable.teal
@@ -1,0 +1,467 @@
+#pragma version 6
+txn NumAppArgs
+int 0
+==
+bnz main_l20
+txna ApplicationArgs 0
+method "add(uint64,uint64)uint64"
+==
+bnz main_l19
+txna ApplicationArgs 0
+method "sub(uint64,uint64)uint64"
+==
+bnz main_l18
+txna ApplicationArgs 0
+method "mul(uint64,uint64)uint64"
+==
+bnz main_l17
+txna ApplicationArgs 0
+method "div(uint64,uint64)uint64"
+==
+bnz main_l16
+txna ApplicationArgs 0
+method "mod(uint64,uint64)uint64"
+==
+bnz main_l15
+txna ApplicationArgs 0
+method "all_laid_to_args(uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64)uint64"
+==
+bnz main_l14
+txna ApplicationArgs 0
+method "empty_return_subroutine()void"
+==
+bnz main_l13
+txna ApplicationArgs 0
+method "log_1()uint64"
+==
+bnz main_l12
+txna ApplicationArgs 0
+method "log_creation()string"
+==
+bnz main_l11
+err
+main_l11:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+==
+&&
+assert
+callsub logcreation_8
+store 67
+byte 0x151f7c75
+load 67
+concat
+log
+int 1
+return
+main_l12:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+txn OnCompletion
+int OptIn
+==
+txn ApplicationID
+int 0
+!=
+&&
+||
+assert
+callsub log1_7
+store 65
+byte 0x151f7c75
+load 65
+itob
+concat
+log
+int 1
+return
+main_l13:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+txn OnCompletion
+int OptIn
+==
+||
+assert
+callsub emptyreturnsubroutine_6
+int 1
+return
+main_l14:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 30
+txna ApplicationArgs 2
+btoi
+store 31
+txna ApplicationArgs 3
+btoi
+store 32
+txna ApplicationArgs 4
+btoi
+store 33
+txna ApplicationArgs 5
+btoi
+store 34
+txna ApplicationArgs 6
+btoi
+store 35
+txna ApplicationArgs 7
+btoi
+store 36
+txna ApplicationArgs 8
+btoi
+store 37
+txna ApplicationArgs 9
+btoi
+store 38
+txna ApplicationArgs 10
+btoi
+store 39
+txna ApplicationArgs 11
+btoi
+store 40
+txna ApplicationArgs 12
+btoi
+store 41
+txna ApplicationArgs 13
+btoi
+store 42
+txna ApplicationArgs 14
+btoi
+store 43
+txna ApplicationArgs 15
+store 46
+load 46
+int 0
+extract_uint64
+store 44
+load 46
+int 8
+extract_uint64
+store 45
+load 30
+load 31
+load 32
+load 33
+load 34
+load 35
+load 36
+load 37
+load 38
+load 39
+load 40
+load 41
+load 42
+load 43
+load 44
+load 45
+callsub alllaidtoargs_5
+store 47
+byte 0x151f7c75
+load 47
+itob
+concat
+log
+int 1
+return
+main_l15:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 24
+txna ApplicationArgs 2
+btoi
+store 25
+load 24
+load 25
+callsub mod_4
+store 26
+byte 0x151f7c75
+load 26
+itob
+concat
+log
+int 1
+return
+main_l16:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 18
+txna ApplicationArgs 2
+btoi
+store 19
+load 18
+load 19
+callsub div_3
+store 20
+byte 0x151f7c75
+load 20
+itob
+concat
+log
+int 1
+return
+main_l17:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 12
+txna ApplicationArgs 2
+btoi
+store 13
+load 12
+load 13
+callsub mul_2
+store 14
+byte 0x151f7c75
+load 14
+itob
+concat
+log
+int 1
+return
+main_l18:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 6
+txna ApplicationArgs 2
+btoi
+store 7
+load 6
+load 7
+callsub sub_1
+store 8
+byte 0x151f7c75
+load 8
+itob
+concat
+log
+int 1
+return
+main_l19:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 0
+txna ApplicationArgs 2
+btoi
+store 1
+load 0
+load 1
+callsub add_0
+store 2
+byte 0x151f7c75
+load 2
+itob
+concat
+log
+int 1
+return
+main_l20:
+txn OnCompletion
+int OptIn
+==
+bnz main_l22
+err
+main_l22:
+txn ApplicationID
+int 0
+!=
+assert
+byte "optin call"
+log
+int 1
+return
+
+// add
+add_0:
+store 4
+store 3
+load 3
+load 4
++
+store 5
+load 5
+retsub
+
+// sub
+sub_1:
+store 10
+store 9
+load 9
+load 10
+-
+store 11
+load 11
+retsub
+
+// mul
+mul_2:
+store 16
+store 15
+load 15
+load 16
+*
+store 17
+load 17
+retsub
+
+// div
+div_3:
+store 22
+store 21
+load 21
+load 22
+/
+store 23
+load 23
+retsub
+
+// mod
+mod_4:
+store 28
+store 27
+load 27
+load 28
+%
+store 29
+load 29
+retsub
+
+// all_laid_to_args
+alllaidtoargs_5:
+store 63
+store 62
+store 61
+store 60
+store 59
+store 58
+store 57
+store 56
+store 55
+store 54
+store 53
+store 52
+store 51
+store 50
+store 49
+store 48
+load 48
+load 49
++
+load 50
++
+load 51
++
+load 52
++
+load 53
++
+load 54
++
+load 55
++
+load 56
++
+load 57
++
+load 58
++
+load 59
++
+load 60
++
+load 61
++
+load 62
++
+load 63
++
+store 64
+load 64
+retsub
+
+// empty_return_subroutine
+emptyreturnsubroutine_6:
+byte "appear in both approval and clear state"
+log
+retsub
+
+// log_1
+log1_7:
+int 1
+store 66
+load 66
+retsub
+
+// log_creation
+logcreation_8:
+byte "logging creation"
+len
+itob
+extract 6 0
+byte "logging creation"
+concat
+store 68
+load 68
+retsub
+
+  

--- a/tests/teal/router/questionable.teal
+++ b/tests/teal/router/questionable.teal
@@ -292,7 +292,7 @@ return
 main_l19:
 txn OnCompletion
 int NoOp
-==                      // I believe there ahould be an assertion here to ensure that this is actually a NoOp
+==
 txn ApplicationID
 int 0
 !=

--- a/tests/teal/router/questionable_clear.teal
+++ b/tests/teal/router/questionable_clear.teal
@@ -1,0 +1,67 @@
+#pragma version 6
+txn NumAppArgs
+int 0
+==
+bnz main_l8
+txna ApplicationArgs 0
+method "empty_return_subroutine()void"
+==
+bnz main_l7
+txna ApplicationArgs 0
+method "log_1()uint64"
+==
+bnz main_l6
+txna ApplicationArgs 0
+method "approve_if_odd(uint32)void"
+==
+bnz main_l5
+err
+main_l5:
+txna ApplicationArgs 1
+int 0
+extract_uint32
+store 2
+load 2
+callsub approveifodd_2
+int 1
+return
+main_l6:
+callsub log1_1
+store 1
+byte 0x151f7c75
+load 1
+itob
+concat
+log
+int 1
+return
+main_l7:
+callsub emptyreturnsubroutine_0
+int 1
+return
+main_l8:
+int 1
+return
+// empty_return_subroutine
+emptyreturnsubroutine_0:
+byte "appear in both approval and clear state"
+log
+retsub
+// log_1
+log1_1:
+int 1
+store 0
+load 0
+retsub
+// approve_if_odd
+approveifodd_2:
+store 3
+load 3
+int 2
+%
+bnz approveifodd_2_l2
+int 0
+return
+approveifodd_2_l2:
+int 1
+return

--- a/tests/teal/router/yacc.teal
+++ b/tests/teal/router/yacc.teal
@@ -1,0 +1,437 @@
+#pragma version 6
+txna ApplicationArgs 0
+method "add(uint64,uint64)uint64"
+==
+bnz main_l18
+txna ApplicationArgs 0
+method "sub(uint64,uint64)uint64"
+==
+bnz main_l17
+txna ApplicationArgs 0
+method "mul(uint64,uint64)uint64"
+==
+bnz main_l16
+txna ApplicationArgs 0
+method "div(uint64,uint64)uint64"
+==
+bnz main_l15
+txna ApplicationArgs 0
+method "mod(uint64,uint64)uint64"
+==
+bnz main_l14
+txna ApplicationArgs 0
+method "all_laid_to_args(uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64,uint64)uint64"
+==
+bnz main_l13
+txna ApplicationArgs 0
+method "empty_return_subroutine()void"
+==
+bnz main_l12
+txna ApplicationArgs 0
+method "log_1()uint64"
+==
+bnz main_l11
+txna ApplicationArgs 0
+method "log_creation()string"
+==
+bnz main_l10
+err
+main_l10:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+==
+&&
+assert
+callsub logcreation_8
+store 67
+byte 0x151f7c75
+load 67
+concat
+log
+int 1
+return
+main_l11:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+txn OnCompletion
+int OptIn
+==
+txn ApplicationID
+int 0
+!=
+&&
+||
+assert
+callsub log1_7
+store 65
+byte 0x151f7c75
+load 65
+itob
+concat
+log
+int 1
+return
+main_l12:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+txn OnCompletion
+int OptIn
+==
+||
+assert
+callsub emptyreturnsubroutine_6
+int 1
+return
+main_l13:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 30
+txna ApplicationArgs 2
+btoi
+store 31
+txna ApplicationArgs 3
+btoi
+store 32
+txna ApplicationArgs 4
+btoi
+store 33
+txna ApplicationArgs 5
+btoi
+store 34
+txna ApplicationArgs 6
+btoi
+store 35
+txna ApplicationArgs 7
+btoi
+store 36
+txna ApplicationArgs 8
+btoi
+store 37
+txna ApplicationArgs 9
+btoi
+store 38
+txna ApplicationArgs 10
+btoi
+store 39
+txna ApplicationArgs 11
+btoi
+store 40
+txna ApplicationArgs 12
+btoi
+store 41
+txna ApplicationArgs 13
+btoi
+store 42
+txna ApplicationArgs 14
+btoi
+store 43
+txna ApplicationArgs 15
+store 46
+load 46
+int 0
+extract_uint64
+store 44
+load 46
+int 8
+extract_uint64
+store 45
+load 30
+load 31
+load 32
+load 33
+load 34
+load 35
+load 36
+load 37
+load 38
+load 39
+load 40
+load 41
+load 42
+load 43
+load 44
+load 45
+callsub alllaidtoargs_5
+store 47
+byte 0x151f7c75
+load 47
+itob
+concat
+log
+int 1
+return
+main_l14:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 24
+txna ApplicationArgs 2
+btoi
+store 25
+load 24
+load 25
+callsub mod_4
+store 26
+byte 0x151f7c75
+load 26
+itob
+concat
+log
+int 1
+return
+main_l15:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 18
+txna ApplicationArgs 2
+btoi
+store 19
+load 18
+load 19
+callsub div_3
+store 20
+byte 0x151f7c75
+load 20
+itob
+concat
+log
+int 1
+return
+main_l16:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 12
+txna ApplicationArgs 2
+btoi
+store 13
+load 12
+load 13
+callsub mul_2
+store 14
+byte 0x151f7c75
+load 14
+itob
+concat
+log
+int 1
+return
+main_l17:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 6
+txna ApplicationArgs 2
+btoi
+store 7
+load 6
+load 7
+callsub sub_1
+store 8
+byte 0x151f7c75
+load 8
+itob
+concat
+log
+int 1
+return
+main_l18:
+txn OnCompletion
+int NoOp
+==
+txn ApplicationID
+int 0
+!=
+&&
+assert
+txna ApplicationArgs 1
+btoi
+store 0
+txna ApplicationArgs 2
+btoi
+store 1
+load 0
+load 1
+callsub add_0
+store 2
+byte 0x151f7c75
+load 2
+itob
+concat
+log
+int 1
+return
+// add
+add_0:
+store 4
+store 3
+load 3
+load 4
++
+store 5
+load 5
+retsub
+// sub
+sub_1:
+store 10
+store 9
+load 9
+load 10
+-
+store 11
+load 11
+retsub
+// mul
+mul_2:
+store 16
+store 15
+load 15
+load 16
+*
+store 17
+load 17
+retsub
+// div
+div_3:
+store 22
+store 21
+load 21
+load 22
+/
+store 23
+load 23
+retsub
+// mod
+mod_4:
+store 28
+store 27
+load 27
+load 28
+%
+store 29
+load 29
+retsub
+// all_laid_to_args
+alllaidtoargs_5:
+store 63
+store 62
+store 61
+store 60
+store 59
+store 58
+store 57
+store 56
+store 55
+store 54
+store 53
+store 52
+store 51
+store 50
+store 49
+store 48
+load 48
+load 49
++
+load 50
++
+load 51
++
+load 52
++
+load 53
++
+load 54
++
+load 55
++
+load 56
++
+load 57
++
+load 58
++
+load 59
++
+load 60
++
+load 61
++
+load 62
++
+load 63
++
+store 64
+load 64
+retsub
+// empty_return_subroutine
+emptyreturnsubroutine_6:
+byte "appear in both approval and clear state"
+log
+retsub
+// log_1
+log1_7:
+int 1
+store 66
+load 66
+retsub
+// log_creation
+logcreation_8:
+byte "logging creation"
+len
+itob
+extract 6 0
+byte "logging creation"
+concat
+store 68
+load 68
+retsub

--- a/tests/teal/router/yacc_clear.teal
+++ b/tests/teal/router/yacc_clear.teal
@@ -1,0 +1,60 @@
+#pragma version 6
+txna ApplicationArgs 0
+method "empty_return_subroutine()void"
+==
+bnz main_l6
+txna ApplicationArgs 0
+method "log_1()uint64"
+==
+bnz main_l5
+txna ApplicationArgs 0
+method "approve_if_odd(uint32)void"
+==
+bnz main_l4
+err
+main_l4:
+txna ApplicationArgs 1
+int 0
+extract_uint32
+store 2
+load 2
+callsub approveifodd_2
+int 1
+return
+main_l5:
+callsub log1_1
+store 1
+byte 0x151f7c75
+load 1
+itob
+concat
+log
+int 1
+return
+main_l6:
+callsub emptyreturnsubroutine_0
+int 1
+return
+// empty_return_subroutine
+emptyreturnsubroutine_0:
+byte "appear in both approval and clear state"
+log
+retsub
+// log_1
+log1_1:
+int 1
+store 0
+load 0
+retsub
+// approve_if_odd
+approveifodd_2:
+store 3
+load 3
+int 2
+%
+bnz approveifodd_2_l2
+int 0
+return
+approveifodd_2_l2:
+int 1
+return

--- a/tests/unit/inspector_test.py
+++ b/tests/unit/inspector_test.py
@@ -11,7 +11,7 @@ def test_from_single_response_errors():
     }
 
     with pytest.raises(AssertionError) as ae:
-        DryRunInspector.from_single_response(error_resp)
+        DryRunInspector.from_single_response(error_resp, None, None)
 
     assert (
         ae.value.args[0]
@@ -25,7 +25,7 @@ def test_from_single_response_errors():
     }
 
     with pytest.raises(AssertionError) as ae:
-        DryRunInspector.from_single_response(no_txns_resp1)
+        DryRunInspector.from_single_response(no_txns_resp1, None, None)
 
     assert (
         ae.value.args[0]
@@ -38,7 +38,7 @@ def test_from_single_response_errors():
     }
 
     with pytest.raises(AssertionError) as ae:
-        DryRunInspector.from_single_response(no_txns_resp2)
+        DryRunInspector.from_single_response(no_txns_resp2, None, None)
 
     assert (
         ae.value.args[0]
@@ -48,7 +48,7 @@ def test_from_single_response_errors():
     too_many_txns_resp = {"protocol-version": "future", "txns": [1, 2, 3]}
 
     with pytest.raises(AssertionError) as ae:
-        DryRunInspector.from_single_response(too_many_txns_resp)
+        DryRunInspector.from_single_response(too_many_txns_resp, None, None)
 
     assert (
         ae.value.args[0]
@@ -62,7 +62,7 @@ def test_from_single_response_errors():
     }
 
     with pytest.raises(AssertionError) as ae:
-        DryRunInspector.from_single_response(too_many_txns_resp_w_err)
+        DryRunInspector.from_single_response(too_many_txns_resp_w_err, None, None)
 
     assert (
         ae.value.args[0]


### PR DESCRIPTION
# Graviton ABI-Router Functionality
Still working on more test cases but the core functionality for testing ABI Router / ARC-4 compliant programs is in place.

## Changes

### Issues addressed

* #5 

### Bugs Fixed

* Fixed a bug in dry run execution which made all app calls run as if during app creation

### Python Support

* Require 3.9 (previously 3.8 was supported)

### New Functionality
* `Makefile` - run `mypy` with `--show-error-codes`
* `graviton/abi_strategy.py` - introducing class `RandomABIStrategyHalfSized` which allows restricting integers to ½ their bit size for testing multiplication and addition without oveflow
* `graviton/blackbox.py` - introducing class `ABIContractExecutor` which applies the functionality of `DryRunExecutor` to the case of ABI-routable programs
* `graviton/invariant.py` - make `mypy` a little happier and other small refactorings. Class `Invariant` was heavily utilized in the new tests
* `tests/integration/abi_test.py` - adding tests of ABI-routable programs. In particular:
  * `test_method_or_barecall_positive` - test all valid method and bare app calls for the contract including consideration of:
    * `is_app_create` - simulate the program execution during app creation, or after it already exists as appropriate
    * `on_complete` - simulate all appropriate OnComplete actions
    * `args` - simulate [NUM_ROUTER_DRYRUNS](https://github.com/algorand/graviton/blob/5ed03a38db14ae2c50f5e8d5d582096c56992dc5/tests/integration/abi_test.py#L236) random sets of valid `args` as inputs for each method (currently `NUM_ROUTER_DRYRUNS = 7`)
    * assert that the program **passes**
    * assert that the output of each method call is exactly as expected (i.e. `sub()` actually subtracts, `add()` adds, etc.)
  * `test_method_or_barecall_negative` - test all _INVALID_ method and bare app calls for the contract. In particular:
    * consider all ***DISALLOWED*** `is_app_create` and `on_complete` combinations with all other parameters valid and verify that the app call is rejected with error
    * remove an argument from an otherwise valid app call and verify that the app call is rejected with error
    * append an extra argument to an otherwise valid app call and verify that the app call is rejected with error
    * edit the method selector (`arg[0]`) by removing/adding/replacing a byte for an otherwise valid app call and verify that the app call is rejected with error

## ABI-Router Bugs? Catalog

### Approval Program Routing
These (alleged) bugs were discovered for the [approval ABI contract](https://github.com/algorand/graviton/blob/5ed03a38db14ae2c50f5e8d5d582096c56992dc5/tests/teal/router/questionable.json) and [program](https://github.com/algorand/graviton/blob/5ed03a38db14ae2c50f5e8d5d582096c56992dc5/tests/teal/router/questionable.teal) generated by PyTeal in `compiler_test.py` as [_router_with_oc](https://github.com/algorand/pyteal/blob/feature/abi/pyteal/compiler/compiler_test.py#L2336)
1. **THIS IS NO LONGER CONSIDERED A BUG** ~Apart from enforcing `txn NumAppArgs > 0`, there is no enforcement that the number of arguments provided to a method is the number expected. Strictly speaking, this is not specified in [ARC-4](https://arc.algorand.foundation/ARCs/arc-0004) however one can read between the lines in [methods](https://arc.algorand.foundation/ARCs/arc-0004#methods) and [implementing a method](https://arc.algorand.foundation/ARCs/arc-0004#implementing-a-method) and argue that this is the intent. in particular "_Invoking a method involves creating an Application call transaction to specifically call that method._" seems like it would imply providing _exactly_ the arguments definied in a method's signature.~
  * ~when `sub` was provided arguments `2837233049, 2497150219, 2497150219` it [PASSED](https://github.com/algorand/graviton/runs/6848069610?check_suite_focus=true#step:12:1994) instead of rejected (`arg[3]` was ignored, but should be disallowed IMO)~
  * ~all the other contract methods suffer the same problem. EG [add](https://github.com/algorand/graviton/runs/6848069610?check_suite_focus=true#step:12:2859)~
  * ~similarly, when `all_laid_args` which can handle 16 non-selector args by converting the last 2 into a tuple was provided 17 non-selector args, it [PASSED](https://github.com/algorand/graviton/runs/6848069610?check_suite_focus=true#step:12:2394). I believe this is a separate issue from the first one which requires a different approach in PyTEAL than the first (i.e., you can't just enforce with `txn NumAppArgs; int {NUMBER_OF_ACTUAL_ARGS}; ==; assert`)~

## Remaining Actions

### Tasks
- [x] Remove the `temporarily_skip_iia` variable in `tests/integration/abi_test.py` and start failing that test again
- [x] Create a PyTEAL issue regarding more efficient scratch slot assignments in the ABI-Router. We can see [here](https://github.com/algorand/graviton/blob/5ed03a38db14ae2c50f5e8d5d582096c56992dc5/tests/teal/router/questionable.teal#L266-L317) that even though `sub` and `add` do not depend on each-other, they enforce the usage of separate scratch slots. For a contract with many methods, this could result in needlessly running out of available slots. Please see [PyTEAL issue 390](https://github.com/algorand/pyteal/issues/390).
- [x] ~Add `test_bad_method_selectors` to verifies that ABI-router program rejects with error invalid method selectors~ (this is actually covered by `test_method_or_barecall_negative`'s "edit the method selector..." scenarios)
- [x] ~Test that REJECT with error or assert when use `arg[0]` different from the selector of any contract method - "_If an Application is called with greater than zero Application call arguments (NOT a bare Application call), the Application MUST always treat the first argument as a method selector and invoke the specified method, regardless of the OnCompletion action of the Application call. This applies to Application creation transactions as well, where the supplied Application ID is 0._"~ (Similarly to the previous, this is also covered by  `test_method_or_barecall_negative`'s "edit the method selector..." scenarios)
- [x] Test the `@ABIReturnSubroutine` [conditional_factorial](https://github.com/algorand/pyteal/blob/feature/abi/pyteal/compiler/compiler_test.py#L2094)  - this is being addressed in [PyTEAL PR #391](https://github.com/algorand/pyteal/pull/391), and in particular in [this test method](https://github.com/algorand/pyteal/blob/5f0561090311e5ebf597a5e207df9cf73a7a9b59/tests/integration/graviton_abi_test.py#L516).
- [x] test  [_router_with_oc](https://github.com/algorand/pyteal/blob/feature/abi/pyteal/compiler/compiler_test.py#L2336)'s [clear state program expected_csp_with_oc](https://github.com/algorand/pyteal/blob/feature/abi/pyteal/compiler/compiler_test.py#L2814)
- [x] test approval and clear state programs for [_router_without_oc](https://github.com/algorand/pyteal/blob/feature/abi/pyteal/compiler/compiler_test.py#L2886)
- [x] Add graviton ABI Routing functionality in PyTEAL via `ABIContractExecutor` and use it to test more realistic programs such as. This is punted to [PyTEAL issue #394](https://github.com/algorand/pyteal/issues/394)
  - [ ] Ben's [demo abi](https://github.com/algorand-devrel/demo-abi/blob/master/contract.py) which includes _**reference**_ and _**transaction**_ type method arguments
  - [ ] Ben's [Priority Queue](https://github.com/barnjamin/vex/blob/7f44c2029f7a922c6c02d5a2d00ce5a97060ed88/vex.py)
- [x] After addressing the related question below and assuming a relevant answer here, ~we would need to add `test_barecall_for_action_implies_methods_allowed`: test that if a bare app call is allowed for a particular `is_app_create, on_complete` combination, then all the contract methods can be called for such combo. This guidance is provided in ARC-4 according to: "_If a Contract elects to allow bare Application calls for some OnCompletion actions, then that Contract SHOULD also allow any of its methods to be called with those OnCompletion actions, as long as this would not cause undesirable or nonsensical behavior._"~ **UPSHOT:** the answer is back and it's "NO - not right now". That is, we are not holding up release on account of this not being implemented. Hence, testing of this functionality is on hold for now.

### Questions

#### ARC-4

- [x] Should strict num-args enforcement be added to ARC-4? - **NO**

#### PyTEAL

- [x] Should we strictly enforce the number of arguments in PyTEAL's ABI-Router implementation? (A counter argument is that it is useful to allow optional extra undocumented arguments for debugging and/or admin purposes... but I can imagine counter-counter arguments as well). **ANSWER**: probably no, as the SDK's likely enforce this. @tzaffi commits to investigating further and writing a cucumber test asserting of this. **UPDATE**: here is the resulting ticket: https://github.com/algorand/algorand-sdk-testing/issues/190
- [x] Should we enforce and/or allow the following in PyTEAL? According to ARC-4, "_If a Contract elects to allow bare Application calls for some OnCompletion actions, then that Contract SHOULD also allow any of its methods to be called with those OnCompletion actions, as long as this would not cause undesirable or nonsensical behavior._" However, this is not the current behavior of PyTEAL generated ABI-Routable programs. In particular, we can see in this branch that there is an [allowable bare app call for opting in](https://github.com/algorand/graviton/blob/5ed03a38db14ae2c50f5e8d5d582096c56992dc5/tests/integration/abi_test.py#L337) but only 2 of the methods (`empty_return_subroutine()` and `log_1()`) is allowed for opting in. **ANSWER:** Ideally, we should follow ARC-4 and allow method calls right after an `opt-in` bare app call, and right before `close-out` bare app calls, but this is not what is currently supported. Currently, we don't compose bare-app calls with method calls. This should not hold up release, however it is important that we be able to upgrade the router and -in order to enable this in the smart contract space- we need to introduce strict ABI Router versioning. @michaeldiamant will draft a story around this. **TLDR;** the answer **_"NO - not right now"_**
- [x] Should an ABI Router generated clear state program explicitly enforce `txn OnCompletion; int ClearState; ==; assert` at the beginning? We can see that [this isn't currently the case](https://github.com/algorand/pyteal/blob/feature/abi/pyteal/compiler/compiler_test.py#L2814). - **NO** however, we should probably make it very easy to generate clear state programs whose entire contents is `int 1`
- [x] Should we allow/encourage/mandate ABI Router-type checking in PyTEAL? I.e., should a PyTEAL ABI Subroutine enforce that its received arguments are of the type expected _in the strictest way possible_ ? (I would argue _not at this time_ because it's a big can of worms with definite downsides, but it's worthy of discussion and possibly a new ticket/issue). **ANSWER**: We should have a way to automatically inject type checking for ABI types, though we may not want to make this the default. @jasonpaulos has thought of the idea of adding a `verify()` method on ABI types.

## Future Work - cf #22

- [ ] Determine if dry runs can be made to handle transaction groups
- [ ] If the determination of the previous is "yes", enable graviton to handle such transaction groups and then use to test abi methods with transaction arguments. In particular, it should verify that when the expected `pay / axfr / ...` transactions are too far away (compared to the number of such args in the method signature) the program is rejected with error.
