### PR TITLE
Adding graviton logo and badges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## `v0.4.1`
+
+### Added
+
+* Better Logos
+* Badges for:
+  * visitor count
+  * "powered by Algorand"
+* New `THANKS.md`
+
 ## `v0.4.0` (_aka_ 🐕)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   * visitor count
   * "powered by Algorand"
 * New `THANKS.md`
+* Original logo including _ALT_ link to graviton journal article in the following tag: `<img width="345" alt="http://cds.cern.ch/record/2315186/files/scoap3-fulltext.pdf" src="https://user-images.githubusercontent.com/291133/160721859-21a3560a-0a82-4249-aa54-5ede4c60f8d2.png">`
 
 ## `v0.4.0` (_aka_ 🐕)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   * visitor count
   * "powered by Algorand"
 * New `THANKS.md`
+
+### Removed
+
 * Original logo including _ALT_ link to graviton journal article in the following tag: `<img width="345" alt="http://cds.cern.ch/record/2315186/files/scoap3-fulltext.pdf" src="https://user-images.githubusercontent.com/291133/160721859-21a3560a-0a82-4249-aa54-5ede4c60f8d2.png">`
 
 ## `v0.4.0` (_aka_ 🐕)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
-# Graviton - Testing TEAL with Dry Runs
+<!-- markdownlint-disable no-inline-html -->
+<!-- markdownlint-disable first-line-h1 -->
+<p align="center"><img  width=100%  src="https://infura-ipfs.io/ipfs/QmRVnM9EaCk3u9p42b5ppLjwxUPv54EDQihmkNyFxqKuVi"  border="0" /></p>
+
+<p align="center">
+    <a href="https://algorand.com"><img src="https://img.shields.io/badge/Powered by-Algorand-teal.svg" alt="Algorand" /></a>
+    <a><img src="https://visitor-badge.glitch.me/badge?page_id=algorand.graviton&right_color=green" /></a>
+</p>
+
+# About
+
+Graviton is a software toolkit for blackbox testing of smart contracts written in TEAL.
 
 ## [Tutorial](./graviton/README.md)
 

--- a/THANKS.md
+++ b/THANKS.md
@@ -1,0 +1,9 @@
+# Thanks
+
+A big thank you to everyone who has contributed to the `graviton` codebase.
+
+## External Contributors
+
+- aorumbayev
+
+<!-- ## Bug Reports -->

--- a/graviton/README.md
+++ b/graviton/README.md
@@ -1,9 +1,12 @@
 <!-- markdownlint-disable no-inline-html -->
 <!-- markdownlint-disable ol-prefix -->
+<!-- markdownlint-disable first-line-h1 -->
+<p align="center"><img  width=100%  src="https://infura-ipfs.io/ipfs/QmUJQFQET7VHyfDepM9CNhGBEabjH42XzK39kAisPWdE3K"  border="0" /></p>
 
-# GRAVITON (aka the TEAL Blackbox Toolkit): Program Reporting and Testing via Dry Runs
+Graviton (aka the TEAL Blackbox Toolkit): Program Reporting and Testing via Dry Runs
 
-<img width="345" alt="http://cds.cern.ch/record/2315186/files/scoap3-fulltext.pdf" src="https://user-images.githubusercontent.com/291133/160721859-21a3560a-0a82-4249-aa54-5ede4c60f8d2.png">
+<!-- Please let me know if you'd like to keep or you think the logo in the header is fine since it also encapsulates the diagram in the letter G -->
+<!-- <img width="345" alt="http://cds.cern.ch/record/2315186/files/scoap3-fulltext.pdf" src="https://user-images.githubusercontent.com/291133/160721859-21a3560a-0a82-4249-aa54-5ede4c60f8d2.png"> -->
 
 **NOTE: to get math formulas to render here using Chrome, add the [xhub extension](https://chrome.google.com/webstore/detail/xhub/anidddebgkllnnnnjfkmjcaallemhjee/related) and reload.**
 

--- a/graviton/README.md
+++ b/graviton/README.md
@@ -5,9 +5,6 @@
 
 Graviton (aka the TEAL Blackbox Toolkit): Program Reporting and Testing via Dry Runs
 
-<!-- Please let me know if you'd like to keep or you think the logo in the header is fine since it also encapsulates the diagram in the letter G -->
-<!-- <img width="345" alt="http://cds.cern.ch/record/2315186/files/scoap3-fulltext.pdf" src="https://user-images.githubusercontent.com/291133/160721859-21a3560a-0a82-4249-aa54-5ede4c60f8d2.png"> -->
-
 **NOTE: to get math formulas to render here using Chrome, add the [xhub extension](https://chrome.google.com/webstore/detail/xhub/anidddebgkllnnnnjfkmjcaallemhjee/related) and reload.**
 
 **DISCLAIMER**: Graviton is subject to change and makes no backwards compatability guarantees.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="graviton",
-    version="0.3.0",
+    version="0.4.1",
     url="https://github.com/algorand/graviton",
     description="verify your TEAL program by experiment and observation",
     long_description=long_description,


### PR DESCRIPTION
## Proposed changes 

- Adds 2 variations on a proposal for graviton logo inspired by [this](https://user-images.githubusercontent.com/291133/160721859-21a3560a-0a82-4249-aa54-5ede4c60f8d2.png) diagram. Main readme contains colored gradient background (teal and green from algorand's website), and tutorial page is reversed black background and gradient on text itself. 
- I noticed that markdownlint is used so i had to add one extra disable for a rule that would prevent having header image as a first content in md file. If you'd like to follow the convention though - feel free to to suggest moving text above the icon.
- Images are hosted on ipfs and here is a .psd version also on ipfs -> `ipfs://QmVcS8ULiEUrzs3m6bFQncuRt4MUV8ydnJmyen2wWCt5uq`, should be possible to download it and edit in photoshop further if needed.
- Lastly adds 2 tiny repo badges (visitors count and link to algorand website), could be used as a starter template in case you wanna add more badges (like coverage, ci status and etc) in future.