### PR TITLE
Update DryRun cost fields and expose DryRun accounts to users

### DIFF
--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -437,7 +437,7 @@ class DryRunExecutor:
         lease: str = None,
         rekey_to: str = None,
         extra_pages: int = None,
-        dryrun_accounts: List[Union[str, Account]]] = [],
+        dryrun_accounts: List[Union[str, Account]] = [],
     ) -> "DryRunInspector":
         """
         Execute a dry run to simulate an app call using provided:

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -50,7 +50,7 @@ class ExecutionMode(Enum):
 
 
 class DryRunProperty(Enum):
-    cost = auto() # deprecated
+    cost = auto()  # deprecated
     budgetAdded = auto()
     budgetConsumed = auto()
     lastLog = auto()
@@ -439,7 +439,7 @@ class DryRunExecutor:
         lease: str = None,
         rekey_to: str = None,
         extra_pages: int = None,
-        dryrun_accounts: List[str | Account] = []
+        dryrun_accounts: List[str | Account] = [],
     ) -> "DryRunInspector":
         """
         Execute a dry run to simulate an app call using provided:
@@ -483,7 +483,7 @@ class DryRunExecutor:
                 foreign_assets=foreign_assets,
                 extra_pages=extra_pages,
             ),
-            accounts=dryrun_accounts
+            accounts=dryrun_accounts,
         )
 
     @classmethod
@@ -533,7 +533,7 @@ class DryRunExecutor:
         abi_return_type: abi.ABIType = None,
         is_app_create: bool = False,
         on_complete: OnComplete = OnComplete.NoOpOC,
-        dryrun_accounts: List[str | Account] = []
+        dryrun_accounts: List[str | Account] = [],
     ) -> List["DryRunInspector"]:
         # TODO: handle txn_params
         return list(
@@ -546,7 +546,7 @@ class DryRunExecutor:
                     abi_return_type=abi_return_type,
                     is_app_create=is_app_create,
                     on_complete=on_complete,
-                    dryrun_accounts=dryrun_accounts
+                    dryrun_accounts=dryrun_accounts,
                 ),
                 inputs,
             )
@@ -596,9 +596,13 @@ class DryRunExecutor:
 
         dryrun_req: DryrunRequest
         if is_app:
-            dryrun_req = DryRunHelper.singleton_app_request(teal, encoded_args, txn_params, accounts)
+            dryrun_req = DryRunHelper.singleton_app_request(
+                teal, encoded_args, txn_params, accounts
+            )
         else:
-            dryrun_req = DryRunHelper.singleton_logicsig_request(teal, encoded_args, txn_params)
+            dryrun_req = DryRunHelper.singleton_logicsig_request(
+                teal, encoded_args, txn_params
+            )
         dryrun_resp = algod.dryrun(dryrun_req)
         return DryRunInspector.from_single_response(
             dryrun_resp, args, encoded_args, abi_type=abi_return_type

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -437,7 +437,7 @@ class DryRunExecutor:
         lease: str = None,
         rekey_to: str = None,
         extra_pages: int = None,
-        dryrun_accounts: List[str | Account] = [],
+        dryrun_accounts: List[Union[str, Account]]] = [],
     ) -> "DryRunInspector":
         """
         Execute a dry run to simulate an app call using provided:
@@ -531,7 +531,7 @@ class DryRunExecutor:
         abi_return_type: abi.ABIType = None,
         is_app_create: bool = False,
         on_complete: OnComplete = OnComplete.NoOpOC,
-        dryrun_accounts: List[str | Account] = [],
+        dryrun_accounts: List[Union[str, Account]] = [],
     ) -> List["DryRunInspector"]:
         # TODO: handle txn_params
         return list(
@@ -583,7 +583,7 @@ class DryRunExecutor:
         abi_argument_types: List[Optional[abi.ABIType]] = None,
         abi_return_type: abi.ABIType = None,
         txn_params: dict = {},
-        accounts: List[str | Account] = [],
+        accounts: List[Union[str, Account]] = [],
     ) -> "DryRunInspector":
         assert (
             len(ExecutionMode) == 2

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -967,6 +967,7 @@ class DryRunInspector:
             return txn["budget-added"]
 
         if dr_property == DryRunProperty.budgetConsumed:
+            print(txn["budget-consumed"])
             return txn["budget-consumed"]
 
         if dr_property == DryRunProperty.lastLog:

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -36,7 +36,7 @@ from graviton.dryrun import (
     DryRunHelper,
 )
 
-from graviton.models import ZERO_ADDRESS
+from graviton.models import ZERO_ADDRESS, ArgType
 
 
 MAX_APP_ARG_LIMIT = atc.AtomicTransactionComposer.MAX_APP_ARG_LIMIT
@@ -271,7 +271,7 @@ class DryRunEncoder:
         cls,
         args: Sequence[PY_TYPES],
         abi_types: List[Optional[abi.ABIType]] = None,
-    ) -> List[Union[bytes, str]]:
+    ) -> List[ArgType]:
         """
         Encoding convention for Black Box Testing.
 
@@ -867,7 +867,7 @@ class DryRunInspector:
         dryrun_resp: dict,
         txn_index: int,
         args: Sequence[PY_TYPES],
-        encoded_args: List[Union[bytes, str]],
+        encoded_args: List[ArgType],
         abi_type: abi.ABIType = None,
     ):
         txns = dryrun_resp.get("txns", [])
@@ -934,7 +934,7 @@ class DryRunInspector:
         cls,
         dryrun_resp: dict,
         args: Sequence[PY_TYPES],
-        encoded_args: List[Union[bytes, str]],
+        encoded_args: List[ArgType],
         abi_type: abi.ABIType = None,
     ) -> "DryRunInspector":
         error = dryrun_resp.get("error")

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -7,7 +7,6 @@ import io
 from tabulate import tabulate
 from typing import (
     Any,
-    Callable,
     Dict,
     Final,
     List,
@@ -28,7 +27,6 @@ from algosdk.future.transaction import (
 )
 
 from algosdk import atomic_transaction_composer as atc
-from graviton import dryrun
 
 from graviton.abi_strategy import PY_TYPES, ABIStrategy, RandomABIStrategy
 

--- a/graviton/dryrun.py
+++ b/graviton/dryrun.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, List, Union
 
 from algosdk.future import transaction
 from algosdk.encoding import encode_address, msgpack_encode
+from algosdk.logic import get_application_address
 from algosdk.v2client.models import (
     DryrunRequest,
     DryrunSource,
@@ -212,13 +213,13 @@ class DryRunHelper:
 
     @classmethod
     def singleton_app_request(
-        cls, program: str, args: List[Union[bytes, str]], txn_params: Dict[str, Any]
+        cls, program: str, args: List[Union[bytes, str]], txn_params: Dict[str, Any], accounts: List[str | Account]
     ):
         creator = txn_params.get("sender")
         app_idx = txn_params.get("index")
         on_complete = txn_params.get("on_complete")
         app = models.App.factory(
-            creator=creator, app_idx=app_idx, on_complete=on_complete, args=args
+            creator=creator, app_idx=app_idx, on_complete=on_complete, args=args, accounts=accounts
         )
         return cls.dryrun_request(program, app, txn_params)
 

--- a/graviton/dryrun.py
+++ b/graviton/dryrun.py
@@ -7,7 +7,6 @@ from typing import Any, Dict, List, Union
 
 from algosdk.future import transaction
 from algosdk.encoding import encode_address, msgpack_encode
-from algosdk.logic import get_application_address
 from algosdk.v2client.models import (
     DryrunRequest,
     DryrunSource,

--- a/graviton/dryrun.py
+++ b/graviton/dryrun.py
@@ -206,7 +206,7 @@ class DryRunHelper:
 
     @classmethod
     def singleton_logicsig_request(
-        cls, program: str, args: List[bytes | str], txn_params: Dict[str, Any]
+        cls, program: str, args: List[Union[bytes, str]], txn_params: Dict[str, Any]
     ):
         return cls.dryrun_request(program, models.LSig(args=args), txn_params)
 
@@ -216,7 +216,7 @@ class DryRunHelper:
         program: str,
         args: List[Union[bytes, str]],
         txn_params: Dict[str, Any],
-        accounts: List[str | Account],
+        accounts: List[Union[str, Account]],
     ):
         creator = txn_params.get("sender")
         app_idx = txn_params.get("index")

--- a/graviton/dryrun.py
+++ b/graviton/dryrun.py
@@ -207,19 +207,27 @@ class DryRunHelper:
 
     @classmethod
     def singleton_logicsig_request(
-        cls, program: str, args: List[bytes], txn_params: Dict[str, Any]
+        cls, program: str, args: List[bytes | str], txn_params: Dict[str, Any]
     ):
         return cls.dryrun_request(program, models.LSig(args=args), txn_params)
 
     @classmethod
     def singleton_app_request(
-        cls, program: str, args: List[Union[bytes, str]], txn_params: Dict[str, Any], accounts: List[str | Account]
+        cls,
+        program: str,
+        args: List[Union[bytes, str]],
+        txn_params: Dict[str, Any],
+        accounts: List[str | Account],
     ):
         creator = txn_params.get("sender")
         app_idx = txn_params.get("index")
         on_complete = txn_params.get("on_complete")
         app = models.App.factory(
-            creator=creator, app_idx=app_idx, on_complete=on_complete, args=args, accounts=accounts
+            creator=creator,
+            app_idx=app_idx,
+            on_complete=on_complete,
+            args=args,
+            accounts=accounts,
         )
         return cls.dryrun_request(program, app, txn_params)
 

--- a/graviton/dryrun.py
+++ b/graviton/dryrun.py
@@ -216,7 +216,7 @@ class DryRunHelper:
         program: str,
         args: List[Union[bytes, str]],
         txn_params: Dict[str, Any],
-        accounts: List[Union[str, Account]],
+        accounts: List[Union[str, Account]] = [],
     ):
         creator = txn_params.get("sender")
         app_idx = txn_params.get("index")

--- a/graviton/dryrun.py
+++ b/graviton/dryrun.py
@@ -16,7 +16,8 @@ from algosdk.v2client.models import (
     Account,
 )
 
-from . import models
+from graviton import models
+from graviton.models import ArgType
 
 PRINTABLE = frozenset(string.printable)
 
@@ -206,7 +207,7 @@ class DryRunHelper:
 
     @classmethod
     def singleton_logicsig_request(
-        cls, program: str, args: List[Union[bytes, str]], txn_params: Dict[str, Any]
+        cls, program: str, args: List[ArgType], txn_params: Dict[str, Any]
     ):
         return cls.dryrun_request(program, models.LSig(args=args), txn_params)
 
@@ -214,7 +215,7 @@ class DryRunHelper:
     def singleton_app_request(
         cls,
         program: str,
-        args: List[Union[bytes, str]],
+        args: List[ArgType],
         txn_params: Dict[str, Any],
         accounts: List[Union[str, Account]] = [],
     ):

--- a/graviton/models.py
+++ b/graviton/models.py
@@ -7,6 +7,8 @@ from algosdk.v2client.models import Account, TealKeyValue
 
 ZERO_ADDRESS = encode_address(bytes(32))
 
+ArgType = Union[bytes, str]
+
 
 def get_run_mode(app):
     run_mode = "lsig"
@@ -24,7 +26,7 @@ def get_run_mode(app):
 class LSig:
     """Logic Sig program parameters"""
 
-    args: Optional[List[Union[bytes, str]]] = None
+    args: Optional[List[ArgType]] = None
 
 
 @dataclass
@@ -35,7 +37,7 @@ class App:
     round: Optional[int] = None
     app_idx: int = 0
     on_complete: int = 0
-    args: Optional[List[Union[bytes, str]]] = None
+    args: Optional[List[ArgType]] = None
     accounts: Optional[List[Union[str, Account]]] = None
     global_state: Optional[List[TealKeyValue]] = None
 

--- a/graviton/models.py
+++ b/graviton/models.py
@@ -24,7 +24,7 @@ def get_run_mode(app):
 class LSig:
     """Logic Sig program parameters"""
 
-    args: Optional[List[bytes | str]] = None
+    args: Optional[List[Union[bytes, str]]] = None
 
 
 @dataclass
@@ -36,7 +36,7 @@ class App:
     app_idx: int = 0
     on_complete: int = 0
     args: Optional[List[Union[bytes, str]]] = None
-    accounts: Optional[List[str | Account]] = None
+    accounts: Optional[List[Union[str, Account]]] = None
     global_state: Optional[List[TealKeyValue]] = None
 
     @classmethod

--- a/graviton/models.py
+++ b/graviton/models.py
@@ -36,7 +36,7 @@ class App:
     app_idx: int = 0
     on_complete: int = 0
     args: Optional[List[Union[bytes, str]]] = None
-    accounts: Optional[List[Union[str, Account]]] = None
+    accounts: Optional[List[str | Account]] = None
     global_state: Optional[List[TealKeyValue]] = None
 
     @classmethod

--- a/graviton/models.py
+++ b/graviton/models.py
@@ -24,7 +24,7 @@ def get_run_mode(app):
 class LSig:
     """Logic Sig program parameters"""
 
-    args: Optional[List[bytes]] = None
+    args: Optional[List[bytes | str]] = None
 
 
 @dataclass

--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -259,7 +259,6 @@ YACC_CLEAR_TEAL = None
 with open(ROUTER / "yacc_clear.teal") as f:
     YACC_CLEAR_TEAL = f.read()
 
-
 QUESTIONABLE_ACE = ABIContractExecutor(
     QUESTIONABLE_TEAL,
     QUESTIONABLE_CONTRACT,
@@ -273,7 +272,6 @@ QUESTIONABLE_CLEAR_ACE = ABIContractExecutor(
     argument_strategy=RandomABIStrategyHalfSized,
     dry_runs=NUM_ROUTER_DRYRUNS,
 )
-
 
 YACC_ACE = ABIContractExecutor(
     YACC_TEAL,

--- a/tests/integration/blackbox_test.py
+++ b/tests/integration/blackbox_test.py
@@ -287,7 +287,7 @@ APP_SCENARIOS = {
             DRProp.cost: lambda args, actual: (
                 actual - 40 <= 17 * args[0] <= actual + 40
             ),
-            DRProp.budgetConsumed: lambda args, actual : (
+            DRProp.budgetConsumed: lambda args, actual: (
                 actual - 40 <= 17 * args[0] <= actual + 40
             ),
             DRProp.budgetAdded: 0,
@@ -317,7 +317,9 @@ APP_SCENARIOS = {
         "inputs": [(i,) for i in range(18)],
         "invariants": {
             DRProp.cost: lambda args: (fib_cost(args) if args[0] < 17 else 70_000),
-            DRProp.budgetConsumed: lambda args: (fib_cost(args) if args[0] < 17 else 70_000),
+            DRProp.budgetConsumed: lambda args: (
+                fib_cost(args) if args[0] < 17 else 70_000
+            ),
             DRProp.budgetAdded: 0,
             DRProp.lastLog: lambda args: (
                 Encoder.hex(fib(args[0])) if args[0] < 17 else None
@@ -385,7 +387,14 @@ def test_app_with_report(filebase: str):
     )
 
     # 2. Run the requests to obtain sequence of Dryrun responses:
-    accounts = [Account(address=get_application_address(Executor.EXISTING_APP_CALL), status="Online", amount=105000000, amount_without_pending_rewards=10500000)]
+    accounts = [
+        Account(
+            address=get_application_address(Executor.EXISTING_APP_CALL),
+            status="Online",
+            amount=105000000,
+            amount_without_pending_rewards=10500000,
+        )
+    ]
     dryrun_results = Executor.dryrun_app_on_sequence(algod, teal, inputs, dryrun_accounts=accounts)  # type: ignore
 
     # 3. Generate statistical report of all the runs:

--- a/tests/integration/blackbox_test.py
+++ b/tests/integration/blackbox_test.py
@@ -412,6 +412,7 @@ def test_app_itxn_with_report():
     scenario_success = {
         "inputs": [()],
         "invariants": {
+            DRProp.cost: -687,
             DRProp.budgetConsumed: 13,
             DRProp.budgetAdded: 700,
             DRProp.status: "PASS",

--- a/tests/teal/app_itxn.teal
+++ b/tests/teal/app_itxn.teal
@@ -1,0 +1,13 @@
+#pragma version 6
+
+itxn_begin
+int appl
+itxn_field TypeEnum
+int DeleteApplication
+itxn_field OnCompletion
+byte 0x068101 // #pragma version 6; int 1;
+itxn_field ApprovalProgram
+byte 0x068101 // #pragma version 6; int 1;
+itxn_field ClearStateProgram
+itxn_submit
+int 1


### PR DESCRIPTION
For certain use cases, it's necessary to set the balance of the app account to some nonzero value. One example is testing inner app calls. This PR allows the users to set balances for accounts and updates the existing dryrun `cost` field (which is now deprecated) and adds support for the new cost fields `BudgetAdded` and `BudgetConsumed`.

Testing: Unit tests.