### PR TITLE
Add ability to assert identical functionality for teal programs/methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 <!-- markdownlint-disable MD024 -->
 # Changelog
 
+## `v0.6.0` (_aka_ 🐸)
+
+### Added
+
+* `class PredicateKind` introduced to strengthen typing of predicates and invariants
+* `PredicateKind.IdenticalPair`: allow asserting identical behavior of teal programs without specifying behavior details
+
 ## `v0.5.0` (_aka_ 🐘)
 
 ### Added

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -655,7 +655,7 @@ class DryRunExecutor:
         if abi_method_signature:
             assert not (
                 abi_argument_types or abi_return_type
-            ), f"provided method {abi_method_signature}, so should not have provided argument types {abi_argument_types} not return type {abi_return_type}"
+            ), f"provided method {abi_method_signature}, so should provide neither argument types {abi_argument_types} nor return type {abi_return_type}"
             method = abi.Method.from_signature(abi_method_signature)
             selector = method.get_selector()
             # the method selector is not abi-encoded, hence its abi-type is set to None

--- a/graviton/blackbox.py
+++ b/graviton/blackbox.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 import io
 
+from graviton.models import ExecutionMode
+
 from tabulate import tabulate
 from typing import (
     Any,
@@ -12,6 +14,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Tuple,
     Type,
     Union,
     cast,
@@ -36,13 +39,9 @@ from graviton.dryrun import (
 )
 from graviton.models import ZERO_ADDRESS, ArgType, DryRunAccountType
 
+TealAndMaybeMethod = Union[Tuple[str], Tuple[str, str]]
 
 MAX_APP_ARG_LIMIT = atc.AtomicTransactionComposer.MAX_APP_ARG_LIMIT
-
-
-class ExecutionMode(Enum):
-    Signature = auto()
-    Application = auto()
 
 
 class DryRunProperty(Enum):
@@ -420,6 +419,7 @@ class DryRunExecutor:
         is_app_create: bool = False,
         on_complete: OnComplete = OnComplete.NoOpOC,
         *,
+        abi_method_signature: Optional[str] = None,
         sender: Optional[str] = None,
         sp: Optional[SuggestedParams] = None,
         index: Optional[int] = None,
@@ -455,6 +455,7 @@ class DryRunExecutor:
             teal,
             args,
             ExecutionMode.Application,
+            abi_method_signature=abi_method_signature,
             abi_argument_types=abi_argument_types,
             abi_return_type=abi_return_type,
             txn_params=cls.transaction_params(
@@ -520,11 +521,70 @@ class DryRunExecutor:
         )
 
     @classmethod
+    def dryrun_app_pair_on_sequence(
+        cls,
+        algod: AlgodClient,
+        teal_and_method1: TealAndMaybeMethod,
+        teal_and_method2: TealAndMaybeMethod,
+        inputs: List[Sequence[PyTypes]],
+        abi_argument_types: Optional[List[Optional[abi.ABIType]]] = None,
+        abi_return_type: Optional[abi.ABIType] = None,
+        is_app_create: bool = False,
+        on_complete: OnComplete = OnComplete.NoOpOC,
+        dryrun_accounts: List[DryRunAccountType] = [],
+    ) -> Tuple[Sequence["DryRunInspector"], Sequence["DryRunInspector"]]:
+        return tuple(  # type: ignore
+            cls.dryrun_multiapps_on_sequence(
+                algod=algod,
+                multi_teal_method_pairs=[teal_and_method1, teal_and_method2],
+                inputs=inputs,
+                abi_argument_types=abi_argument_types,
+                abi_return_type=abi_return_type,
+                is_app_create=is_app_create,
+                on_complete=on_complete,
+                dryrun_accounts=dryrun_accounts,
+            )
+        )
+
+    @classmethod
+    def dryrun_multiapps_on_sequence(
+        cls,
+        algod: AlgodClient,
+        multi_teal_method_pairs: List[TealAndMaybeMethod],
+        inputs: List[Sequence[PyTypes]],
+        abi_argument_types: Optional[List[Optional[abi.ABIType]]] = None,
+        abi_return_type: Optional[abi.ABIType] = None,
+        is_app_create: bool = False,
+        on_complete: OnComplete = OnComplete.NoOpOC,
+        dryrun_accounts: List[DryRunAccountType] = [],
+    ) -> List[Sequence["DryRunInspector"]]:
+        def runner(teal_method_pair):
+            teal = teal_method_pair[0]
+            abi_method = None
+            if len(teal_method_pair) > 1:
+                abi_method = teal_method_pair[1]
+
+            return cls.dryrun_app_on_sequence(
+                algod=algod,
+                teal=teal,
+                inputs=inputs,
+                abi_method=abi_method,
+                abi_argument_types=abi_argument_types,
+                abi_return_type=abi_return_type,
+                is_app_create=is_app_create,
+                on_complete=on_complete,
+                dryrun_accounts=dryrun_accounts,
+            )
+
+        return list(map(runner, multi_teal_method_pairs))
+
+    @classmethod
     def dryrun_app_on_sequence(
         cls,
         algod: AlgodClient,
         teal: str,
         inputs: List[Sequence[PyTypes]],
+        abi_method: Optional[str] = None,
         abi_argument_types: Optional[List[Optional[abi.ABIType]]] = None,
         abi_return_type: Optional[abi.ABIType] = None,
         is_app_create: bool = False,
@@ -538,6 +598,7 @@ class DryRunExecutor:
                     algod=algod,
                     teal=teal,
                     args=args,
+                    abi_method_signature=abi_method,
                     abi_argument_types=abi_argument_types,
                     abi_return_type=abi_return_type,
                     is_app_create=is_app_create,
@@ -578,16 +639,30 @@ class DryRunExecutor:
         teal: str,
         args: Sequence[PyTypes],
         mode: ExecutionMode,
+        abi_method_signature: Optional[str] = None,
         abi_argument_types: Optional[List[Optional[abi.ABIType]]] = None,
         abi_return_type: Optional[abi.ABIType] = None,
         txn_params: dict = {},
         accounts: List[DryRunAccountType] = [],
+        verbose: bool = False,
     ) -> "DryRunInspector":
         assert (
             len(ExecutionMode) == 2
         ), f"assuming only 2 ExecutionMode's but have {len(ExecutionMode)}"
         assert mode in ExecutionMode, f"unknown mode {mode} of type {type(mode)}"
         is_app = mode == ExecutionMode.Application
+
+        if abi_method_signature:
+            assert not (
+                abi_argument_types or abi_return_type
+            ), f"provided method {abi_method_signature}, so should not have provided argument types {abi_argument_types} not return type {abi_return_type}"
+            method = abi.Method.from_signature(abi_method_signature)
+            selector = method.get_selector()
+            # the method selector is not abi-encoded, hence its abi-type is set to None
+            abi_argument_types = [None] + [a.type for a in method.args]
+            args = tuple([selector] + list(args))
+            abi_return_type = method.returns.type
+
         encoded_args = DryRunEncoder.encode_args(args, abi_types=abi_argument_types)
 
         dryrun_req: DryrunRequest
@@ -599,7 +674,11 @@ class DryRunExecutor:
             dryrun_req = DryRunHelper.singleton_logicsig_request(
                 teal, encoded_args, txn_params
             )
+        if verbose:
+            print(f"{cls}::execute_one_dryrun(): {dryrun_req=}")
         dryrun_resp = algod.dryrun(dryrun_req)
+        if verbose:
+            print(f"{cls}::execute_one_dryrun(): {dryrun_resp=}")
         return DryRunInspector.from_single_response(
             dryrun_resp, args, encoded_args, abi_type=abi_return_type
         )
@@ -895,6 +974,12 @@ class DryRunInspector:
             has_abi_prefix=bool(self.abi_type),
             show_internal_errors_on_log=True,
         )
+
+    def method_selector_param(self) -> Optional[str]:
+        return cast(str, self.args[0]) if self.abi_type else None
+
+    def abi_params_or_args(self) -> Tuple[PyTypes, ...]:
+        return tuple(self.args[1:] if self.abi_type else self.args)
 
     def config(self, **kwargs: bool):
         bad_keys = set(kwargs.keys()) - self.CONFIG_OPTIONS

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -96,13 +96,18 @@ class Invariant:
         self,
         args: Sequence[PyTypes],
         actual: PyTypes,
-        external_expected: Optional[PyTypes] = None,
+        **kwargs,
     ) -> Tuple[bool, str]:
+        has_external_expected: bool = False
+        if kwargs and (ee_key := "external_expected") in kwargs:
+            has_external_expected = True
+            external_expected: Optional[PyTypes] = kwargs[ee_key]
         invariant = (
-            self.predicate(args, actual)
-            if external_expected is None
-            else self.predicate(args, actual, external_expected)
+            self.predicate(args, actual, external_expected)
+            if has_external_expected
+            else self.predicate(args, actual)
         )
+
         msg = ""
         if not invariant:
             expected = (
@@ -152,7 +157,7 @@ class Invariant:
                 ), f"IdenticalPair predicates expects the same argments but they aren't: {inspector.abi_params_or_args()=} V. {identity.abi_params_or_args()=}"
                 expected = identity.dig(dr_property)
                 actual = inspector.dig(dr_property)
-                ok, fail_msg = self(inspector.args, actual, expected)
+                ok, fail_msg = self(inspector.args, actual, external_expected=expected)
                 if msg:
                     fail_msg += f". invariant provided message:{msg}"
                 assert ok, inspector.report(msg=fail_msg, row=i + 1)

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -127,8 +127,12 @@ class Invariant:
         return invariant, msg
 
     def expected(self, x: Any, y: Any = None) -> PyTypes:
-        return self._expected(x) if y is None else self._expected(x, y)
-
+        return (
+            self._expected(x, y)
+            if self.predicate_kind == PredicateKind.IdenticalPair or y is not None
+            else self._expected(x)
+        )
+        
     def validates(
         self,
         dr_property: DryRunProperty,

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -132,7 +132,7 @@ class Invariant:
             if self.predicate_kind == PredicateKind.IdenticalPair or y is not None
             else self._expected(x)
         )
-        
+
     def validates(
         self,
         dr_property: DryRunProperty,

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -111,9 +111,9 @@ class Invariant:
         msg = ""
         if not invariant:
             expected = (
-                self.expected(args)
-                if external_expected is None
-                else self.expected(actual, external_expected)
+                self.expected(actual, external_expected)
+                if has_external_expected
+                else self.expected(args)
             )
             prefix = f"Invariant of {self.predicate_kind} for '{self.name}' failed for for args {args!r}: "
             if self.predicate_kind == PredicateKind.IdenticalPair:

--- a/graviton/invariant.py
+++ b/graviton/invariant.py
@@ -210,63 +210,6 @@ class Invariant:
 
         raise ValueError("Unhanlded PredicateKind {kind} for predicate {predicate}")
 
-    # @classmethod
-    # def prepare_predicate(
-    #     cls,
-    #     predicate: INVARIANT_TYPE,
-    # ) -> Tuple[Callable, Callable]:
-    #     if isinstance(predicate, PredicateKind):
-    #         assert predicate == PredicateKind.IdenticalPair
-    #         # equality between 2 inspectors
-    #         return (
-    #             lambda f1, f2, args: f1(args) == f2(args),
-    #             lambda f1, f2, args: (f1(args), f2(args)),
-    #         )
-
-    #     # returns
-    #     # * Callable[[Sequence[PY_TYPES], PY_TYPES], bool]
-    #     # * Callable[[Sequence[PY_TYPES]], PY_TYPES]
-    #     if isinstance(predicate, dict):
-    #         d_predicate = cast(Dict[PyTypes, PyTypes], predicate)
-    #         return (
-    #             lambda args, actual: d_predicate[args] == actual,
-    #             lambda args: d_predicate[args],
-    #         )
-
-    #     # returns
-    #     # * Callable[[Any], PY_TYPES], bool]
-    #     # * Callable[[Any], PY_TYPES]
-    #     if not callable(predicate):
-    #         # constant function in this case:
-    #         a_const = predicate
-    #         return lambda _, actual: a_const == actual, lambda _: a_const
-
-    #     try:
-    #         sig = signature(predicate)
-    #     except Exception as e:
-    #         raise Exception(
-    #             f"callable predicate {predicate} must have a signature"
-    #         ) from e
-
-    #     N = len(sig.parameters)
-    #     assert N in (1, 2), f"predicate has the wrong number of paramters {N}"
-
-    #     if N == 2:
-    #         c2_predicate = cast(Callable[[Sequence[PyTypes], PyTypes], bool], predicate)
-    #         # returns
-    #         # * Callable[[Sequence[PY_TYPES], PY_TYPES], bool]
-    #         # * Callable[Any, Callable[[Sequence[PY_TYPES], PY_TYPES], bool]]
-    #         return c2_predicate, lambda _: c2_predicate
-
-    #     # N == 1:
-    #     c1_predicate = cast(Callable[[Sequence[PyTypes]], bool], predicate)
-    #     # returns
-    #     # * Callable[[Sequence[PY_TYPES]], bool]
-    #     # * Callable[[Sequence[PY_TYPES]], PY_TYPES]
-    #     return lambda args, actual: c1_predicate(
-    #         args
-    #     ) == actual, lambda args: c1_predicate(args)
-
     @classmethod
     def inputs_and_invariants(
         cls,

--- a/graviton/models.py
+++ b/graviton/models.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import List, Optional, Sequence, Union
 
 from algosdk.encoding import encode_address
@@ -10,6 +11,11 @@ ZERO_ADDRESS = encode_address(bytes(32))
 ArgType = Union[bytes, str]
 DryRunAccountType = Union[str, Account]
 PyTypes = Union[bool, int, Sequence, str, bytes]
+
+
+class ExecutionMode(Enum):
+    Signature = auto()
+    Application = auto()
 
 
 def get_run_mode(app):

--- a/tests/integration/identical_test.py
+++ b/tests/integration/identical_test.py
@@ -121,7 +121,10 @@ def test_identical_functions(teal_method1, teal_method2, inputs, predicates):
         algod, teal_method1, teal_method2, inputs
     )
     Invariant.full_validation(
-        predicates, inspectors=inspectors1, identities=inspectors2
+        predicates,
+        inspectors=inspectors1,
+        identities=inspectors2,
+        msg=f"{teal_method1[1]} v. {teal_method2[1]}",
     )
 
 
@@ -138,8 +141,7 @@ def test_non_identical():
         DRProp.lastMessage: "PASS",
     }
     Invariant.full_validation(
-        square_predicates,
-        inspectors=square_inspectors,
+        square_predicates, inspectors=square_inspectors, msg="square by itself"
     )
 
     square_p1_predicates = deepcopy(square_predicates)
@@ -147,8 +149,7 @@ def test_non_identical():
         DRProp.lastLog
     ](args)
     Invariant.full_validation(
-        square_p1_predicates,
-        inspectors=square_p1_inspectors,
+        square_p1_predicates, inspectors=square_p1_inspectors, msg="square_p1 by itself"
     )
 
     with pytest.raises(AssertionError) as ae:
@@ -156,6 +157,7 @@ def test_non_identical():
             identity_predicates,
             inspectors=square_inspectors,
             identities=square_p1_inspectors,
+            msg="square v. square_p1",
         )
 
     assert (

--- a/tests/integration/identical_test.py
+++ b/tests/integration/identical_test.py
@@ -127,7 +127,7 @@ def test_identical_functions(teal_method1, teal_method2, inputs, predicates):
 
 def test_non_identical():
     algod = get_algod()
-    square_inspectores, square_p1_inspectors = DRExecutor.dryrun_app_pair_on_sequence(
+    square_inspectors, square_p1_inspectors = DRExecutor.dryrun_app_pair_on_sequence(
         algod, square, square_p1, ten
     )
 
@@ -139,7 +139,7 @@ def test_non_identical():
     }
     Invariant.full_validation(
         square_predicates,
-        inspectors=square_inspectores,
+        inspectors=square_inspectors,
     )
 
     square_p1_predicates = deepcopy(square_predicates)
@@ -154,7 +154,7 @@ def test_non_identical():
     with pytest.raises(AssertionError) as ae:
         Invariant.full_validation(
             identity_predicates,
-            inspectors=square_inspectores,
+            inspectors=square_inspectors,
             identities=square_p1_inspectors,
         )
 

--- a/tests/integration/identical_test.py
+++ b/tests/integration/identical_test.py
@@ -3,7 +3,7 @@ import pytest
 
 
 from graviton.blackbox import DryRunProperty as DRProp, DryRunExecutor as DRExecutor
-from graviton.invariant import Invariant, PredicateKind as IQ
+from graviton.invariant import Invariant, PredicateKind
 
 from tests.clients import get_algod
 
@@ -99,10 +99,10 @@ square_byref = (square_byref_teal, "square_byref(uint64)uint64")
 square_p1 = (square_plus_1_teal, "square(uint64)uint64")
 ten = [(i,) for i in range(10)]
 identity_predicates = {
-    DRProp.lastLog: IQ.IdenticalPair,
-    DRProp.status: IQ.IdenticalPair,
-    DRProp.error: IQ.IdenticalPair,
-    DRProp.lastMessage: IQ.IdenticalPair,
+    DRProp.lastLog: PredicateKind.IdenticalPair,
+    DRProp.status: PredicateKind.IdenticalPair,
+    DRProp.error: PredicateKind.IdenticalPair,
+    DRProp.lastMessage: PredicateKind.IdenticalPair,
 }
 
 

--- a/tests/integration/identical_test.py
+++ b/tests/integration/identical_test.py
@@ -5,8 +5,6 @@ import pytest
 from graviton.blackbox import DryRunProperty as DRProp, DryRunExecutor as DRExecutor
 from graviton.invariant import Invariant, PredicateKind as IQ
 
-# from graviton.models import ExecutionMode
-
 from tests.clients import get_algod
 
 square_teal = """#pragma version 7
@@ -127,7 +125,7 @@ def test_identical_functions(teal_method1, teal_method2, inputs, predicates):
     )
 
 
-def test_non_idenical():
+def test_non_identical():
     algod = get_algod()
     square_inspectores, square_p1_inspectors = DRExecutor.dryrun_app_pair_on_sequence(
         algod, square, square_p1, ten

--- a/tests/integration/identical_test.py
+++ b/tests/integration/identical_test.py
@@ -1,0 +1,166 @@
+from copy import deepcopy
+import pytest
+
+
+from graviton.blackbox import DryRunProperty as DRProp, DryRunExecutor as DRExecutor
+from graviton.invariant import Invariant, PredicateKind as IQ
+
+# from graviton.models import ExecutionMode
+
+from tests.clients import get_algod
+
+square_teal = """#pragma version 7
+txna ApplicationArgs 0
+method "square(uint64)uint64"
+==
+assert
+txna ApplicationArgs 1
+btoi
+callsub square_0
+store 1
+load 1
+itob
+byte 0x151f7c75
+swap
+concat
+log
+int 1
+return
+
+// square
+square_0:
+store 0
+load 0
+pushint 2 // 2
+exp
+retsub"""
+
+square_plus_1_teal = """#pragma version 7
+txna ApplicationArgs 0
+method "square(uint64)uint64"
+==
+assert
+txna ApplicationArgs 1
+btoi
+callsub square_0
+store 1
+load 1
+itob
+byte 0x151f7c75
+swap
+concat
+log
+int 1
+return
+
+// square
+square_0:
+store 0
+load 0
+pushint 2 // 2
+exp
+int 1
++
+retsub"""
+
+
+square_byref_teal = """#pragma version 7
+txna ApplicationArgs 0
+method "square_byref(uint64)uint64"
+==
+assert
+txna ApplicationArgs 1
+btoi
+store 2
+pushint 2 // 2
+callsub squarebyref_0
+// pushint 1337 // 1337 - TODO expose this for counter example
+load 2
+itob
+byte 0x151f7c75
+swap
+concat
+log
+int 1
+return
+
+// square_byref
+squarebyref_0:
+store 0
+load 0
+load 0
+loads
+load 0
+loads
+*
+stores
+retsub"""
+
+square = (square_teal, "square(uint64)uint64")
+square_byref = (square_byref_teal, "square_byref(uint64)uint64")
+square_p1 = (square_plus_1_teal, "square(uint64)uint64")
+ten = [(i,) for i in range(10)]
+identity_predicates = {
+    DRProp.lastLog: IQ.IdenticalPair,
+    DRProp.status: IQ.IdenticalPair,
+    DRProp.error: IQ.IdenticalPair,
+    DRProp.lastMessage: IQ.IdenticalPair,
+}
+
+
+COPACETIC = [
+    (square, square, ten, identity_predicates),
+    (square, square_byref, ten, identity_predicates),
+    (square_byref, square, ten, identity_predicates),
+    (square_byref, square_byref, ten, identity_predicates),
+]
+
+
+@pytest.mark.parametrize("teal_method1, teal_method2, inputs, predicates", COPACETIC)
+def test_identical_functions(teal_method1, teal_method2, inputs, predicates):
+    algod = get_algod()
+    inspectors1, inspectors2 = DRExecutor.dryrun_app_pair_on_sequence(
+        algod, teal_method1, teal_method2, inputs
+    )
+    Invariant.full_validation(
+        predicates, inspectors=inspectors1, identities=inspectors2
+    )
+
+
+def test_non_idenical():
+    algod = get_algod()
+    square_inspectores, square_p1_inspectors = DRExecutor.dryrun_app_pair_on_sequence(
+        algod, square, square_p1, ten
+    )
+
+    square_predicates = {
+        DRProp.lastLog: lambda args: args[1] ** 2,
+        DRProp.status: "PASS",
+        DRProp.error: False,
+        DRProp.lastMessage: "PASS",
+    }
+    Invariant.full_validation(
+        square_predicates,
+        inspectors=square_inspectores,
+    )
+
+    square_p1_predicates = deepcopy(square_predicates)
+    square_p1_predicates[DRProp.lastLog] = lambda args: 1 + square_predicates[
+        DRProp.lastLog
+    ](args)
+    Invariant.full_validation(
+        square_p1_predicates,
+        inspectors=square_p1_inspectors,
+    )
+
+    with pytest.raises(AssertionError) as ae:
+        Invariant.full_validation(
+            identity_predicates,
+            inspectors=square_inspectores,
+            identities=square_p1_inspectors,
+        )
+
+    assert (
+        "Invariant of PredicateKind.IdenticalPair for 'DryRunProperty.lastLog' failed for for args (b'}\\\\R\\xfa', 0): (actual, expected) = (0, 1)"
+        in str(ae.value)
+    )


### PR DESCRIPTION
# Test one teal program against another, with the optionality of using ABI

## New functionality

The best place to see the new capabilities is in [identical_test.py](https://github.com/algorand/graviton/blob/93f1b58e5bcdf5a0aa7d528a9268149d2e996d99/tests/integration/identical_test.py)

* Add a new method `Invariant.full_validation()` that accepts the standard `inspectors` parameter of dry run execution results, but also the new parameter `identities` which is a sequence of inspectors used to assert equivalence with `inspectors`
* Also allow the pre-existing method `Invariant.validates()` to accept the `identities` parameter
* Add a new class `PredicateKind` to better signal which kind of predicate is being supplied to an `Invariant`
  * The value `PredicateKind.IdenticalPair` acts as a sentinel for asserting that two dry-run execution scenarios are identical

## Testing
C.I.

Also, C.I. in [PyTeal PR #605](https://github.com/algorand/pyteal/pull/605) provides additional coverage.