### PR TITLE
Bugfix: error message changed due to boxes merge

### DIFF
--- a/tests/integration/abi_test.py
+++ b/tests/integration/abi_test.py
@@ -501,7 +501,7 @@ EXPECTED_ERR_PATTERN = r"""
     assert\ failed                              # pyteal generated assert's ok
 |   err\ opcode                                 # pyteal generated err's ok
 |   invalid\ ApplicationArgs\ index             # failing because an app arg wasn't provided
-|   extract\ range\ beyond\ length\ of\ string  # failing because couldn't extract from jammed in tuple
+|   extraction\ end\ [0-9]+\ is\ beyond\ length # failing because couldn't extract from jammed in tuple
 """
 
 NEGATIVE_INVARIANTS = Invariant.as_invariants(


### PR DESCRIPTION
# New expected error message for integration tests

A new error message [broke the integration tests](https://github.com/algorand/graviton/actions/runs/3641016232/jobs/6245433844#step:12:2096).

Here's a screenshot from a `go-algorand` **git blame** that explains:

<img width="1805" alt="image" src="https://user-images.githubusercontent.com/291133/207607200-3c34c6d9-05a9-47e3-914f-4de8e0e1198c.png">

This PR modifies the expected message accordingly.