### PR TITLE
Add support for global_state in dryruns

### DIFF
--- a/graviton/models.py
+++ b/graviton/models.py
@@ -13,7 +13,7 @@ ArgType = Union[bytes, str]
 DryRunAccountType = Union[str, Account]
 Stringy = Union[str, bytes]
 PyTypes = Union[bool, int, Sequence, Stringy]
-
+TealValueish = Union[str, bytes, int]
 
 class ExecutionMode(Enum):
     Signature = auto()


### PR DESCRIPTION
These changes add a `global_state` field to `DryRunTransactionPrams`.

Example code showing a possible usage:
```python
from graviton.blackbox import DryRunExecutor, ExecutionMode, DryRunTransactionParams
from tests.clients import get_algod
teal = """
#pragma version 8
byte "value"
app_global_get
btoi
return
"""
algod = get_algod()
executor = DryRunExecutor(algod, ExecutionMode.Application, teal)
txn_params = DryRunTransactionParams.for_app(global_state={"value": b"\xff"})
run = executor.run_one((), txn_params=txn_params)
print(run.tabulate(500))
print("Cost:", run.cost())
```
Output:
```
   step |   PC# |   L# | Teal                              | Scratch   | Stack
--------+-------+------+-----------------------------------+-----------+----------------
      1 |     1 |    1 | #pragma version 8                 |           | []
      2 |     8 |    2 | pushbytes 0x76616c7565 // "value" |           | [0x76616c7565]
      3 |     9 |    3 | app_global_get                    |           | [0xff]
      4 |    10 |    4 | btoi                              |           | [255]
      5 |    11 |    5 | return                            |           | [255]
Cost: 4
```